### PR TITLE
Add push_workers_to_ecr.sh script for ECR image deployment

### DIFF
--- a/.claude/hooks/update-worker-docs.sh
+++ b/.claude/hooks/update-worker-docs.sh
@@ -2,9 +2,11 @@
 # Claude Code PostToolUse hook — regenerates worker docs when a PR is created.
 #
 # Triggers after any Bash tool call. Checks whether the command was a
-# "gh pr create" invocation; if so, regenerates all worker .md files and
-# registry.md, then commits and pushes the changes to the current branch so
-# that the PR includes up-to-date documentation.
+# "gh pr create"/"gh pr edit" invocation AND whether the branch actually
+# changed worker source (workers/ or generate_worker_docs.py) vs. the base; if
+# so, regenerates all worker .md files and registry.md, then commits and pushes
+# the changes to the current branch so the PR includes up-to-date documentation.
+# PRs that don't touch worker source are skipped (no churn commit).
 #
 # Hook input (stdin): JSON from Claude Code with shape:
 #   { "tool_name": "Bash", "tool_input": { "command": "..." }, ... }
@@ -37,6 +39,28 @@ echo "[update-worker-docs] PR operation detected — regenerating worker documen
 # ── 3. Locate repo root ───────────────────────────────────────────────────────
 REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$REPO_ROOT"
+
+# ── 3b. Skip unless the PR actually changed worker source ─────────────────────
+# The hook fires on any `gh pr create|edit`, including description-only edits.
+# Regenerating + committing docs on a PR that didn't touch any worker source is
+# just noise — an unrelated PR (e.g. a build-script change) would otherwise pick
+# up a registry-churn commit. Only proceed when the branch's diff vs. the base
+# touches workers/ or the generator itself. If no base can be determined, fall
+# through and regenerate (don't silently stop producing docs).
+BASE_REF=""
+for ref in origin/master master origin/main main; do
+    if git rev-parse --verify --quiet "$ref" >/dev/null; then BASE_REF="$ref"; break; fi
+done
+if [ -n "$BASE_REF" ]; then
+    if git diff --name-only "${BASE_REF}...HEAD" -- workers/ generate_worker_docs.py | grep -q .; then
+        echo "[update-worker-docs] Worker source changed vs ${BASE_REF}; regenerating docs."
+    else
+        echo "[update-worker-docs] PR changed no worker source (workers/ or generate_worker_docs.py); skipping doc regen."
+        exit 0
+    fi
+else
+    echo "[update-worker-docs] No base ref found; regenerating docs to be safe."
+fi
 
 # ── 4. Run the documentation generator ───────────────────────────────────────
 if ! python3 generate_worker_docs.py; then

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Local buildx cache populated by scripts/push_workers_to_ecr.sh
+.cache/
+
+# Build logs
+build.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,9 @@ them to AWS ECR. It's a local-only workflow; run it from your laptop after
 sourcing production AWS credentials. It always uses the production
 `Dockerfile` (never `Dockerfile_M1`) and builds for `linux/amd64`.
 
+**Full reference (auth, options, base-image handling, gotchas, GPU/ML notes):
+[`scripts/PUSH_WORKERS_TO_ECR.md`](scripts/PUSH_WORKERS_TO_ECR.md).**
+
 On macOS the script needs bash 4+ (system bash is 3.2); install with
 `brew install bash` and invoke it explicitly (`/opt/homebrew/bin/bash`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,22 +87,29 @@ them to AWS ECR. It's a local-only workflow; run it from your laptop after
 sourcing production AWS credentials. It always uses the production
 `Dockerfile` (never `Dockerfile_M1`) and builds for `linux/amd64`.
 
+On macOS the script needs bash 4+ (system bash is 3.2); install with
+`brew install bash` and invoke it explicitly (`/opt/homebrew/bin/bash`).
+
 ```bash
-# 1. Source AWS credentials (account + region + creds)
-source aws_credentials_prod
+# 1. Source AWS credentials (sets keys + session token; region defaults to us-east-1)
+source ../AWSDeploy/aws_credentials_prod.sh
 
 # 2. See available worker names (discovered from workers/)
-./scripts/push_workers_to_ecr.sh --list
+/opt/homebrew/bin/bash scripts/push_workers_to_ecr.sh --list
 
 # 3. Build & push one or more workers
-./scripts/push_workers_to_ecr.sh blob_metrics_worker connect_timelapse
+/opt/homebrew/bin/bash scripts/push_workers_to_ecr.sh blob_metrics_worker connect_timelapse
 
 # Or push every discovered worker (asks first)
-./scripts/push_workers_to_ecr.sh --all
+/opt/homebrew/bin/bash scripts/push_workers_to_ecr.sh --all
 
 # Print actions without running them
-./scripts/push_workers_to_ecr.sh --dry-run blob_metrics_worker
+/opt/homebrew/bin/bash scripts/push_workers_to_ecr.sh --dry-run blob_metrics_worker
 ```
+
+> **Worker names are directory names, not compose service names.** Use
+> `--list` to get the exact names (e.g. `blob_metrics_worker`, not the
+> `blob_metrics` compose service).
 
 Each push tags two images per worker:
 
@@ -115,14 +122,35 @@ Each push tags two images per worker:
 `aws sts get-caller-identity` and the region from `$AWS_REGION` (default
 `us-east-1`, overridable with `--region`). The ECR repo prefix defaults to
 `nimbus` and is overridable with `--prefix`. ECR repos are created on
-first push (with a confirmation prompt; use `-y` to skip prompts).
+first push (with a confirmation prompt; use `-y` to skip prompts). The SHA
+tag gets a `-dirty` suffix if the working tree has uncommitted changes.
+
+**Base images.** Workers build `FROM nimbusimage/<base>:latest`, which is
+not on any public registry and is normally built locally for the host's
+architecture (so it can't be used for an amd64 cross-build). The script
+therefore builds each needed base (`worker-base`, `image-processing-base`,
+`test-worker-base`) for `linux/amd64`, pushes it to `nimbus/base/<base>`,
+and redirects the worker's `FROM` to that ECR copy via
+`docker buildx --build-context` — no worker Dockerfile edits required. The
+base build runs a full conda env-create under QEMU emulation on macOS, so
+it is slow (~10-15 min) the first time; pass `--skip-base` on later runs to
+reuse a base already pushed to ECR.
+
+**Build context.** Worker Dockerfiles are inconsistent: most COPY
+repo-root-relative paths (e.g. `./workers/<cat>/<name>/entrypoint.py`) and
+build from the repo root, while a few (cellpose, stardist, random_point, …)
+COPY worker-dir-relative paths (e.g. `./environment.yml`). The script
+auto-detects the correct context per worker by checking where each
+`COPY`/`ADD` source resolves, so both layouts build correctly under `--all`.
 
 The script keeps a per-worker buildx cache under `.cache/buildx/<worker>/`
-so reruns are fast; `--no-cache` disables it for one run. Requires bash 4+
-(install via `brew install bash` on macOS).
+(and per-base under `.cache/buildx/base-<base>/`) so reruns are fast;
+`--no-cache` disables it for one run.
 
 Piscis (which has a non-standard `predict/` + `train/` subdirectory layout)
 is not handled by this script; build it via `build_machine_learning_workers.sh`.
+GPU/ML workers (cellpose family, stardist, condensatenet) have their
+contexts detected correctly but are best built via the ML build script.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,10 +150,15 @@ The script keeps a per-worker buildx cache under `.cache/buildx/<worker>/`
 (and per-base under `.cache/buildx/base-<base>/`) so reruns are fast;
 `--no-cache` disables it for one run.
 
-Piscis (which has a non-standard `predict/` + `train/` subdirectory layout)
-is not handled by this script; build it via `build_machine_learning_workers.sh`.
-GPU/ML workers (cellpose family, stardist, condensatenet) have their
-contexts detected correctly but are best built via the ML build script.
+GPU/ML workers (cellpose family, sam*, stardist, condensatenet, deconwolf,
+deepcell, cellori, piscis) build `FROM` public `nvidia/cuda` images, so they
+need no base redirect and are built+pushed by this script too. They're best
+built on a native amd64/GPU host (an EC2 instance) — cross-building CUDA under
+QEMU on a Mac is slow/fragile, so the script warns before doing so. Use
+`--skip-ml` for a fast standard-only laptop run, or `--only-ml` on a GPU box.
+Piscis (non-standard `predict/` + `train/` layout) is handled as two
+pseudo-workers, `piscis_predict` and `piscis_train`. `build_machine_learning_workers.sh`
+remains the local-dev build path (local tags, no ECR push).
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,50 @@ MAC_DEVELOPMENT_MODE=true ./build_workers.sh deconwolf
 ./build_test_workers.sh --build-and-run-tests
 ```
 
+### Pushing Worker Images to AWS ECR
+
+`scripts/push_workers_to_ecr.sh` builds one or more worker images and pushes
+them to AWS ECR. It's a local-only workflow; run it from your laptop after
+sourcing production AWS credentials. It always uses the production
+`Dockerfile` (never `Dockerfile_M1`) and builds for `linux/amd64`.
+
+```bash
+# 1. Source AWS credentials (account + region + creds)
+source aws_credentials_prod
+
+# 2. See available worker names (discovered from workers/)
+./scripts/push_workers_to_ecr.sh --list
+
+# 3. Build & push one or more workers
+./scripts/push_workers_to_ecr.sh blob_metrics_worker connect_timelapse
+
+# Or push every discovered worker (asks first)
+./scripts/push_workers_to_ecr.sh --all
+
+# Print actions without running them
+./scripts/push_workers_to_ecr.sh --dry-run blob_metrics_worker
+```
+
+Each push tags two images per worker:
+
+```
+<acct>.dkr.ecr.<region>.amazonaws.com/nimbus/<category>/<worker>:<short-git-sha>
+<acct>.dkr.ecr.<region>.amazonaws.com/nimbus/<category>/<worker>:latest
+```
+
+`<category>` is `annotations` or `properties`. The account ID comes from
+`aws sts get-caller-identity` and the region from `$AWS_REGION` (default
+`us-east-1`, overridable with `--region`). The ECR repo prefix defaults to
+`nimbus` and is overridable with `--prefix`. ECR repos are created on
+first push (with a confirmation prompt; use `-y` to skip prompts).
+
+The script keeps a per-worker buildx cache under `.cache/buildx/<worker>/`
+so reruns are fast; `--no-cache` disables it for one run. Requires bash 4+
+(install via `brew install bash` on macOS).
+
+Piscis (which has a non-standard `predict/` + `train/` subdirectory layout)
+is not handled by this script; build it via `build_machine_learning_workers.sh`.
+
 ## Architecture
 
 ### Worker Types

--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -23,8 +23,8 @@ Create new annotations by segmenting images or connecting existing annotations.
 |--------|-------------|-----|-------|------|
 | Claude natural language analyzer | Uses Claude AI to analyze images |  |  | [docs](workers/annotations/ai_analysis/AI_ANALYSIS.md) |
 | Cellori Segmentation |  | Yes |  | [docs](workers/annotations/cellori_segmentation/CELLORI_SEGMENTATION.md) |
-| Cellpose | Uses Cellpose to find cells and nuclei | Yes |  | [docs](workers/annotations/cellpose/CELLPOSE.md) |
-| Cellpose retrain | Retrains Cellpose models based on user-selected images | Yes |  | [docs](workers/annotations/cellpose_train/CELLPOSE_TRAIN.md) |
+| Cellpose | This tool runs the Cellpose model to segment the image into cells. Learn more | Yes |  | [docs](workers/annotations/cellpose/CELLPOSE.md) |
+| Cellpose retrain | This tool trains a Cellpose model using user-corrected annotations. Learn more | Yes |  | [docs](workers/annotations/cellpose_train/CELLPOSE_TRAIN.md) |
 | Cellpose-SAM | This tool runs the Cellpose-SAM model to segment the image into cells. Learn more | Yes |  | [docs](workers/annotations/cellposesam/CELLPOSESAM.md) |
 | CondensateNet segmentation | Segments biomolecular condensates using CondensateNet deep learning model | Yes |  | [docs](workers/annotations/condensatenet/CONDENSATENET.md) |
 | Connect Sequential | This tool connects objects sequentially across time or z-slices.It is useful for connec... |  | Yes | [docs](workers/annotations/connect_sequential/CONNECT_SEQUENTIAL.md) |
@@ -36,13 +36,13 @@ Create new annotations by segmenting images or connecting existing annotations.
 | Gaussian Blur | Applies Gaussian blur to images |  | Yes | [docs](workers/annotations/gaussian_blur/GAUSSIAN_BLUR.md) |
 | H&E Deconvolution | Deconvolves H&E stains |  | Yes | [docs](workers/annotations/h_and_e_deconvolution/H_AND_E_DECONVOLUTION.md) |
 | Histogram Matching | Corrects images using histogram matching |  | Yes | [docs](workers/annotations/histogram_matching/HISTOGRAM_MATCHING.md) |
-| Laplacian of Gaussian | Detects spots in images using the Laplacian of Gaussian method |  |  | [docs](workers/annotations/laplacian_of_gaussian/LAPLACIAN_OF_GAUSSIAN.md) |
+| Laplacian of Gaussian | This tool finds spots in an image using the Laplacian of Gaussian method.It uses a filt... |  |  | [docs](workers/annotations/laplacian_of_gaussian/LAPLACIAN_OF_GAUSSIAN.md) |
 | Time lapse registration | Corrects images using time lapse registration |  | Yes | [docs](workers/annotations/registration/REGISTRATION.md) |
 | Rolling Ball | Corrects images using a rolling ball |  | Yes | [docs](workers/annotations/rolling_ball/ROLLING_BALL.md) |
 | SAM2 automatic mask generator | Uses SAM2 to find all masks in the image | Yes |  | [docs](workers/annotations/sam2_automatic_mask_generator/SAM2_AUTOMATIC_MASK_GENERATOR.md) |
 | SAM2 few-shot segmentation | Uses SAM2 features for few-shot segmentation based on training annotations | Yes | Yes | [docs](workers/annotations/sam2_fewshot_segmentation/SAM2_FEWSHOT_SEGMENTATION.md) |
-| SAM2 propagator | Uses SAM2 to propagate annotations through time or Z-slices | Yes |  | [docs](workers/annotations/sam2_propagate/SAM2_PROPAGATE.md) |
-| SAM2 Refiner | Uses SAM2 to refine annotations | Yes |  | [docs](workers/annotations/sam2_refine/SAM2_REFINE.md) |
+| SAM2 propagator | This tool uses the SAM2 model to take an existing annotation and propagate it through t... | Yes |  | [docs](workers/annotations/sam2_propagate/SAM2_PROPAGATE.md) |
+| SAM2 Refiner | This tool uses the SAM2 model to refine existing annotations. It takes existing annotat... | Yes |  | [docs](workers/annotations/sam2_refine/SAM2_REFINE.md) |
 | SAM2 video | Uses SAM2 to track video through time or Z | Yes |  | [docs](workers/annotations/sam2_video/SAM2_VIDEO.md) |
 | SAM automatic mask generator | Uses SAM to find all masks in the image | Yes |  | [docs](workers/annotations/sam_automatic_mask_generator/SAM_AUTOMATIC_MASK_GENERATOR.md) |
 | SAM few-shot segmentation | Uses SAM1 ViT-H features for few-shot segmentation based on training annotations | Yes | Yes | [docs](workers/annotations/sam_fewshot_segmentation/SAM_FEWSHOT_SEGMENTATION.md) |
@@ -54,16 +54,16 @@ Compute properties on polygon / blob annotations.
 
 | Worker | Description | Tests | Docs |
 |--------|-------------|-------|------|
-| Annulus intensity percentile measurements | Compute intensity at a specific percentile for an annular region around blobs | Yes | [docs](workers/properties/blobs/blob_annulus_intensity_percentile_worker/BLOB_ANNULUS_INTENSITY_PERCENTILE_WORKER.md) |
-| Annulus intensity measurements | Compute intensity measurements (mean, median, etc.) for an annular region around blobs | Yes | [docs](workers/properties/blobs/blob_annulus_intensity_worker/BLOB_ANNULUS_INTENSITY_WORKER.md) |
+| Annulus intensity percentile measurements | This tool computes the pixel intensity in an annulus around the objects in the specifie... | Yes | [docs](workers/properties/blobs/blob_annulus_intensity_percentile_worker/BLOB_ANNULUS_INTENSITY_PERCENTILE_WORKER.md) |
+| Annulus intensity measurements | This tool computes the pixel intensity in an annulus around the objects in the specifie... | Yes | [docs](workers/properties/blobs/blob_annulus_intensity_worker/BLOB_ANNULUS_INTENSITY_WORKER.md) |
 | Colony two color intensity | Compute intensity across two channels for blobs; useful for colony intensity measurements |  | [docs](workers/properties/blobs/blob_colony_two_color_intensity_worker/BLOB_COLONY_TWO_COLOR_INTENSITY_WORKER.md) |
-| Blob intensity percentile measurements | Compute intensity at a specific percentile for blobs | Yes | [docs](workers/properties/blobs/blob_intensity_percentile_worker/BLOB_INTENSITY_PERCENTILE_WORKER.md) |
-| Blob intensity measurements | Compute intensity measurements (mean, median, etc.) for blobs | Yes | [docs](workers/properties/blobs/blob_intensity_worker/BLOB_INTENSITY_WORKER.md) |
-| Blob metrics | Compute area, perimeter, and other metrics for blobs | Yes | [docs](workers/properties/blobs/blob_metrics_worker/BLOB_METRICS_WORKER.md) |
-| Blob overlap | Compute overlap between blobs | Yes | [docs](workers/properties/blobs/blob_overlap_worker/BLOB_OVERLAP_WORKER.md) |
+| Blob intensity percentile measurements | This tool computes the pixel intensity of objects in the specified channel at the speci... | Yes | [docs](workers/properties/blobs/blob_intensity_percentile_worker/BLOB_INTENSITY_PERCENTILE_WORKER.md) |
+| Blob intensity measurements | This tool computes the pixel intensity of objects in the specified channel. It will com... | Yes | [docs](workers/properties/blobs/blob_intensity_worker/BLOB_INTENSITY_WORKER.md) |
+| Blob metrics | This tool computes a variety of metrics for the objects in the specified channel. The m... | Yes | [docs](workers/properties/blobs/blob_metrics_worker/BLOB_METRICS_WORKER.md) |
+| Blob overlap | This tool computes the overlaps between two sets of annotations. The overlap is compute... | Yes | [docs](workers/properties/blobs/blob_overlap_worker/BLOB_OVERLAP_WORKER.md) |
 | Point count 3D projection | Count points in a 3D projection |  | [docs](workers/properties/blobs/blob_point_count_3D_projection_worker/BLOB_POINT_COUNT_3D_PROJECTION_WORKER.md) |
-| Point count | Count the number of points that fall within a blob/polygon; can work in 2D or 3D | Yes | [docs](workers/properties/blobs/blob_point_count_worker/BLOB_POINT_COUNT_WORKER.md) |
-| Random Forest Classifier | Classify blobs using a Random Forest Classifier | Yes | [docs](workers/properties/blobs/blob_random_forest_classifier/BLOB_RANDOM_FOREST_CLASSIFIER.md) |
+| Point count | This tool counts the number of points within polygon annotations. The points will be of... | Yes | [docs](workers/properties/blobs/blob_point_count_worker/BLOB_POINT_COUNT_WORKER.md) |
+| Random Forest Classifier | This tool uses a Random Forest Classifier to classify blobs. | Yes | [docs](workers/properties/blobs/blob_random_forest_classifier/BLOB_RANDOM_FOREST_CLASSIFIER.md) |
 
 ## Property Workers -- Points
 
@@ -72,9 +72,9 @@ Compute properties on point annotations.
 | Worker | Description | Tests | Docs |
 |--------|-------------|-------|------|
 | Point circle intensity | Computes mean intensity metrics around a point; radius 1 for pixel precision |  | [docs](workers/properties/points/point_circle_intensity_mean_worker/POINT_CIRCLE_INTENSITY_MEAN_WORKER.md) |
-| Point intensity | Computes a variety of intensity metrics around a point; radius 1 for pixel precision | Yes | [docs](workers/properties/points/point_circle_intensity_worker/POINT_CIRCLE_INTENSITY_WORKER.md) |
+| Point intensity | This tool computes the average, maximum, minimum, median, total, 25th percentile, and 7... | Yes | [docs](workers/properties/points/point_circle_intensity_worker/POINT_CIRCLE_INTENSITY_WORKER.md) |
 | Point Intensity Worker |  |  | [docs](workers/properties/points/point_intensity_worker/POINT_INTENSITY_WORKER.md) |
-| Point metrics | Computes a variety of metrics for points, like X and Y coordinates | Yes | [docs](workers/properties/points/point_metrics_worker/POINT_METRICS_WORKER.md) |
+| Point metrics | This tool adds a property to the points to document their coordinates. It gives each po... | Yes | [docs](workers/properties/points/point_metrics_worker/POINT_METRICS_WORKER.md) |
 | Point Threshold Intensity Mean Worker |  |  | [docs](workers/properties/points/point_threshold_intensity_mean_worker/POINT_THRESHOLD_INTENSITY_MEAN_WORKER.md) |
 | Distance to nearest blob |  | Yes | [docs](workers/properties/points/point_to_nearest_blob_distance/POINT_TO_NEAREST_BLOB_DISTANCE.md) |
 | Distance from point to nearest other point |  |  | [docs](workers/properties/points/point_to_nearest_connected_point_distance/POINT_TO_NEAREST_CONNECTED_POINT_DISTANCE.md) |
@@ -86,8 +86,8 @@ Compute properties on line annotations.
 
 | Worker | Description | Tests | Docs |
 |--------|-------------|-------|------|
-| length | Compute the length of lines |  | [docs](workers/properties/lines/line_length_worker/LINE_LENGTH_WORKER.md) |
-| Line scan CSV | This tool computes the intensity along a line and puts the results in a CSV file. The i... |  | [docs](workers/properties/lines/line_scan_worker/LINE_SCAN_WORKER.md) |
+| length | Computes the length of lines. |  | [docs](workers/properties/lines/line_length_worker/LINE_LENGTH_WORKER.md) |
+| Line scan CSV | This tool computes the intensity along a line and puts the results in a CSV file. The i... | Yes | [docs](workers/properties/lines/line_scan_worker/LINE_SCAN_WORKER.md) |
 | Test File Creation |  |  | [docs](workers/properties/lines/test_file_creation_worker/TEST_FILE_CREATION_WORKER.md) |
 
 ## Property Workers -- Connections
@@ -96,8 +96,8 @@ Compute properties based on relationships between annotations.
 
 | Worker | Description | Tests | Docs |
 |--------|-------------|-------|------|
-| Count connected objects | Count the number of children objects that are connected to a parent polygon | Yes | [docs](workers/properties/connections/children_count_worker/CHILDREN_COUNT_WORKER.md) |
-| Connection IDs | Creates a set of identifiers that indicate the parent-child relationships between polygons | Yes | [docs](workers/properties/connections/parent_child_worker/PARENT_CHILD_WORKER.md) |
+| Count connected objects | This tool counts the number of children objects that are connected to a parent polygon.... | Yes | [docs](workers/properties/connections/children_count_worker/CHILDREN_COUNT_WORKER.md) |
+| Connection IDs | This tool adds a property to the objects to document the connections between them, whic... | Yes | [docs](workers/properties/connections/parent_child_worker/PARENT_CHILD_WORKER.md) |
 
 ## Test / Sample Workers
 
@@ -108,8 +108,8 @@ Workers used for testing and demonstration -- not intended for production use.
 | Annulus Generator M1 |  |  |  | [docs](workers/annotations/annulus_generator_M1/ANNULUS_GENERATOR_M1.md) |
 | Random point | Creates random point annotations |  |  | [docs](workers/annotations/random_point/RANDOM_POINT.md) |
 | Random Point Annotation M1 |  |  |  | [docs](workers/annotations/random_point_annotation_M1/RANDOM_POINT_ANNOTATION_M1.md) |
-| Random squares | Generates random square polygon annotations for testing |  | Yes | [docs](workers/annotations/random_squares/RANDOM_SQUARES.md) |
-| Sample interface | Demonstrates all interface types, messaging patterns, and batch mode |  | Yes | [docs](workers/annotations/sample_interface/SAMPLE_INTERFACE.md) |
+| Random squares | Generates random square polygon annotations within the image bounds. Useful for testing... |  | Yes | [docs](workers/annotations/random_squares/RANDOM_SQUARES.md) |
+| Sample interface | This is a sample interface worker that demonstrates all available interface types, tool... |  | Yes | [docs](workers/annotations/sample_interface/SAMPLE_INTERFACE.md) |
 | Test Multiple Annotation |  |  |  | [docs](workers/annotations/test_multiple_annotation/TEST_MULTIPLE_ANNOTATION.md) |
 | Test Multiple Annotation M1 |  |  |  | [docs](workers/annotations/test_multiple_annotation_M1/TEST_MULTIPLE_ANNOTATION_M1.md) |
 

--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -23,26 +23,26 @@ Create new annotations by segmenting images or connecting existing annotations.
 |--------|-------------|-----|-------|------|
 | Claude natural language analyzer | Uses Claude AI to analyze images |  |  | [docs](workers/annotations/ai_analysis/AI_ANALYSIS.md) |
 | Cellori Segmentation |  | Yes |  | [docs](workers/annotations/cellori_segmentation/CELLORI_SEGMENTATION.md) |
-| Cellpose | This tool runs the Cellpose model to segment the image into cells. Learn more | Yes |  | [docs](workers/annotations/cellpose/CELLPOSE.md) |
-| Cellpose retrain | This tool trains a Cellpose model using user-corrected annotations. Learn more | Yes |  | [docs](workers/annotations/cellpose_train/CELLPOSE_TRAIN.md) |
-| Cellpose-SAM | This tool runs the Cellpose-SAM model to segment the image into cells. Learn more | Yes |  | [docs](workers/annotations/cellposesam/CELLPOSESAM.md) |
+| Cellpose | Uses Cellpose to find cells and nuclei | Yes |  | [docs](workers/annotations/cellpose/CELLPOSE.md) |
+| Cellpose retrain | Retrains Cellpose models based on user-selected images | Yes |  | [docs](workers/annotations/cellpose_train/CELLPOSE_TRAIN.md) |
+| Cellpose-SAM | Uses Cellpose-SAM to find cells and nuclei | Yes |  | [docs](workers/annotations/cellposesam/CELLPOSESAM.md) |
 | CondensateNet segmentation | Segments biomolecular condensates using CondensateNet deep learning model | Yes |  | [docs](workers/annotations/condensatenet/CONDENSATENET.md) |
-| Connect Sequential | This tool connects objects sequentially across time or z-slices.It is useful for connec... |  | Yes | [docs](workers/annotations/connect_sequential/CONNECT_SEQUENTIAL.md) |
-| Connect Time Lapse | This tool connects objects across time slices. It allows you to connect objects even if... |  | Yes | [docs](workers/annotations/connect_timelapse/CONNECT_TIMELAPSE.md) |
-| Connect to Nearest | This tool connects annotations to their nearest neighbors. It will connect from objects... |  | Yes | [docs](workers/annotations/connect_to_nearest/CONNECT_TO_NEAREST.md) |
+| Connect Sequential | Connects objects sequentially across time or z-slices |  | Yes | [docs](workers/annotations/connect_sequential/CONNECT_SEQUENTIAL.md) |
+| Connect Time Lapse | Connects objects across time slices |  | Yes | [docs](workers/annotations/connect_timelapse/CONNECT_TIMELAPSE.md) |
+| Connect to Nearest | Connects objects to each other based on distance |  | Yes | [docs](workers/annotations/connect_to_nearest/CONNECT_TO_NEAREST.md) |
 | Crop | Crops images, allowing you to drop particular slices of data and crop to blobs or recta... |  | Yes | [docs](workers/annotations/crop/CROP.md) |
 | Deconwolf Deconvolution | Deconvolves images using Richardson-Lucy algorithm with Born-Wolf PSF model (GPU-accele... | Yes | Yes | [docs](workers/annotations/deconwolf/DECONWOLF.md) |
 | Deepcell |  | Yes |  | [docs](workers/annotations/deepcell/DEEPCELL.md) |
 | Gaussian Blur | Applies Gaussian blur to images |  | Yes | [docs](workers/annotations/gaussian_blur/GAUSSIAN_BLUR.md) |
 | H&E Deconvolution | Deconvolves H&E stains |  | Yes | [docs](workers/annotations/h_and_e_deconvolution/H_AND_E_DECONVOLUTION.md) |
 | Histogram Matching | Corrects images using histogram matching |  | Yes | [docs](workers/annotations/histogram_matching/HISTOGRAM_MATCHING.md) |
-| Laplacian of Gaussian | This tool finds spots in an image using the Laplacian of Gaussian method.It uses a filt... |  |  | [docs](workers/annotations/laplacian_of_gaussian/LAPLACIAN_OF_GAUSSIAN.md) |
+| Laplacian of Gaussian | Detects spots in images using the Laplacian of Gaussian method |  |  | [docs](workers/annotations/laplacian_of_gaussian/LAPLACIAN_OF_GAUSSIAN.md) |
 | Time lapse registration | Corrects images using time lapse registration |  | Yes | [docs](workers/annotations/registration/REGISTRATION.md) |
 | Rolling Ball | Corrects images using a rolling ball |  | Yes | [docs](workers/annotations/rolling_ball/ROLLING_BALL.md) |
 | SAM2 automatic mask generator | Uses SAM2 to find all masks in the image | Yes |  | [docs](workers/annotations/sam2_automatic_mask_generator/SAM2_AUTOMATIC_MASK_GENERATOR.md) |
 | SAM2 few-shot segmentation | Uses SAM2 features for few-shot segmentation based on training annotations | Yes | Yes | [docs](workers/annotations/sam2_fewshot_segmentation/SAM2_FEWSHOT_SEGMENTATION.md) |
-| SAM2 propagator | This tool uses the SAM2 model to take an existing annotation and propagate it through t... | Yes |  | [docs](workers/annotations/sam2_propagate/SAM2_PROPAGATE.md) |
-| SAM2 Refiner | This tool uses the SAM2 model to refine existing annotations. It takes existing annotat... | Yes |  | [docs](workers/annotations/sam2_refine/SAM2_REFINE.md) |
+| SAM2 propagator | Uses SAM2 to propagate annotations through time or Z-slices | Yes |  | [docs](workers/annotations/sam2_propagate/SAM2_PROPAGATE.md) |
+| SAM2 Refiner | Uses SAM2 to refine annotations | Yes |  | [docs](workers/annotations/sam2_refine/SAM2_REFINE.md) |
 | SAM2 video | Uses SAM2 to track video through time or Z | Yes |  | [docs](workers/annotations/sam2_video/SAM2_VIDEO.md) |
 | SAM automatic mask generator | Uses SAM to find all masks in the image | Yes |  | [docs](workers/annotations/sam_automatic_mask_generator/SAM_AUTOMATIC_MASK_GENERATOR.md) |
 | SAM few-shot segmentation | Uses SAM1 ViT-H features for few-shot segmentation based on training annotations | Yes | Yes | [docs](workers/annotations/sam_fewshot_segmentation/SAM_FEWSHOT_SEGMENTATION.md) |
@@ -54,16 +54,16 @@ Compute properties on polygon / blob annotations.
 
 | Worker | Description | Tests | Docs |
 |--------|-------------|-------|------|
-| Annulus intensity percentile measurements | This tool computes the pixel intensity in an annulus around the objects in the specifie... | Yes | [docs](workers/properties/blobs/blob_annulus_intensity_percentile_worker/BLOB_ANNULUS_INTENSITY_PERCENTILE_WORKER.md) |
-| Annulus intensity measurements | This tool computes the pixel intensity in an annulus around the objects in the specifie... | Yes | [docs](workers/properties/blobs/blob_annulus_intensity_worker/BLOB_ANNULUS_INTENSITY_WORKER.md) |
+| Annulus intensity percentile measurements | Compute intensity at a specific percentile for an annular region around blobs | Yes | [docs](workers/properties/blobs/blob_annulus_intensity_percentile_worker/BLOB_ANNULUS_INTENSITY_PERCENTILE_WORKER.md) |
+| Annulus intensity measurements | Compute intensity measurements (mean, median, etc.) for an annular region around blobs | Yes | [docs](workers/properties/blobs/blob_annulus_intensity_worker/BLOB_ANNULUS_INTENSITY_WORKER.md) |
 | Colony two color intensity | Compute intensity across two channels for blobs; useful for colony intensity measurements |  | [docs](workers/properties/blobs/blob_colony_two_color_intensity_worker/BLOB_COLONY_TWO_COLOR_INTENSITY_WORKER.md) |
-| Blob intensity percentile measurements | This tool computes the pixel intensity of objects in the specified channel at the speci... | Yes | [docs](workers/properties/blobs/blob_intensity_percentile_worker/BLOB_INTENSITY_PERCENTILE_WORKER.md) |
-| Blob intensity measurements | This tool computes the pixel intensity of objects in the specified channel. It will com... | Yes | [docs](workers/properties/blobs/blob_intensity_worker/BLOB_INTENSITY_WORKER.md) |
-| Blob metrics | This tool computes a variety of metrics for the objects in the specified channel. The m... | Yes | [docs](workers/properties/blobs/blob_metrics_worker/BLOB_METRICS_WORKER.md) |
-| Blob overlap | This tool computes the overlaps between two sets of annotations. The overlap is compute... | Yes | [docs](workers/properties/blobs/blob_overlap_worker/BLOB_OVERLAP_WORKER.md) |
+| Blob intensity percentile measurements | Compute intensity at a specific percentile for blobs | Yes | [docs](workers/properties/blobs/blob_intensity_percentile_worker/BLOB_INTENSITY_PERCENTILE_WORKER.md) |
+| Blob intensity measurements | Compute intensity measurements (mean, median, etc.) for blobs | Yes | [docs](workers/properties/blobs/blob_intensity_worker/BLOB_INTENSITY_WORKER.md) |
+| Blob metrics | Compute area, perimeter, and other metrics for blobs | Yes | [docs](workers/properties/blobs/blob_metrics_worker/BLOB_METRICS_WORKER.md) |
+| Blob overlap | Compute overlap between blobs | Yes | [docs](workers/properties/blobs/blob_overlap_worker/BLOB_OVERLAP_WORKER.md) |
 | Point count 3D projection | Count points in a 3D projection |  | [docs](workers/properties/blobs/blob_point_count_3D_projection_worker/BLOB_POINT_COUNT_3D_PROJECTION_WORKER.md) |
-| Point count | This tool counts the number of points within polygon annotations. The points will be of... | Yes | [docs](workers/properties/blobs/blob_point_count_worker/BLOB_POINT_COUNT_WORKER.md) |
-| Random Forest Classifier | This tool uses a Random Forest Classifier to classify blobs. | Yes | [docs](workers/properties/blobs/blob_random_forest_classifier/BLOB_RANDOM_FOREST_CLASSIFIER.md) |
+| Point count | Count the number of points that fall within a blob/polygon; can work in 2D or 3D | Yes | [docs](workers/properties/blobs/blob_point_count_worker/BLOB_POINT_COUNT_WORKER.md) |
+| Random Forest Classifier | Classify blobs using a Random Forest Classifier | Yes | [docs](workers/properties/blobs/blob_random_forest_classifier/BLOB_RANDOM_FOREST_CLASSIFIER.md) |
 
 ## Property Workers -- Points
 
@@ -72,9 +72,9 @@ Compute properties on point annotations.
 | Worker | Description | Tests | Docs |
 |--------|-------------|-------|------|
 | Point circle intensity | Computes mean intensity metrics around a point; radius 1 for pixel precision |  | [docs](workers/properties/points/point_circle_intensity_mean_worker/POINT_CIRCLE_INTENSITY_MEAN_WORKER.md) |
-| Point intensity | This tool computes the average, maximum, minimum, median, total, 25th percentile, and 7... | Yes | [docs](workers/properties/points/point_circle_intensity_worker/POINT_CIRCLE_INTENSITY_WORKER.md) |
+| Point intensity | Computes a variety of intensity metrics around a point; radius 1 for pixel precision | Yes | [docs](workers/properties/points/point_circle_intensity_worker/POINT_CIRCLE_INTENSITY_WORKER.md) |
 | Point Intensity Worker |  |  | [docs](workers/properties/points/point_intensity_worker/POINT_INTENSITY_WORKER.md) |
-| Point metrics | This tool adds a property to the points to document their coordinates. It gives each po... | Yes | [docs](workers/properties/points/point_metrics_worker/POINT_METRICS_WORKER.md) |
+| Point metrics | Computes a variety of metrics for points, like X and Y coordinates | Yes | [docs](workers/properties/points/point_metrics_worker/POINT_METRICS_WORKER.md) |
 | Point Threshold Intensity Mean Worker |  |  | [docs](workers/properties/points/point_threshold_intensity_mean_worker/POINT_THRESHOLD_INTENSITY_MEAN_WORKER.md) |
 | Distance to nearest blob |  | Yes | [docs](workers/properties/points/point_to_nearest_blob_distance/POINT_TO_NEAREST_BLOB_DISTANCE.md) |
 | Distance from point to nearest other point |  |  | [docs](workers/properties/points/point_to_nearest_connected_point_distance/POINT_TO_NEAREST_CONNECTED_POINT_DISTANCE.md) |
@@ -86,8 +86,8 @@ Compute properties on line annotations.
 
 | Worker | Description | Tests | Docs |
 |--------|-------------|-------|------|
-| length | Computes the length of lines. |  | [docs](workers/properties/lines/line_length_worker/LINE_LENGTH_WORKER.md) |
-| Line scan CSV | This tool computes the intensity along a line and puts the results in a CSV file. The i... | Yes | [docs](workers/properties/lines/line_scan_worker/LINE_SCAN_WORKER.md) |
+| length | Compute the length of lines |  | [docs](workers/properties/lines/line_length_worker/LINE_LENGTH_WORKER.md) |
+| Line scan CSV | Compute the intensity along a line and puts the results in a CSV file | Yes | [docs](workers/properties/lines/line_scan_worker/LINE_SCAN_WORKER.md) |
 | Test File Creation |  |  | [docs](workers/properties/lines/test_file_creation_worker/TEST_FILE_CREATION_WORKER.md) |
 
 ## Property Workers -- Connections
@@ -96,8 +96,8 @@ Compute properties based on relationships between annotations.
 
 | Worker | Description | Tests | Docs |
 |--------|-------------|-------|------|
-| Count connected objects | This tool counts the number of children objects that are connected to a parent polygon.... | Yes | [docs](workers/properties/connections/children_count_worker/CHILDREN_COUNT_WORKER.md) |
-| Connection IDs | This tool adds a property to the objects to document the connections between them, whic... | Yes | [docs](workers/properties/connections/parent_child_worker/PARENT_CHILD_WORKER.md) |
+| Count connected objects | Count the number of children objects that are connected to a parent polygon | Yes | [docs](workers/properties/connections/children_count_worker/CHILDREN_COUNT_WORKER.md) |
+| Connection IDs | Creates a set of identifiers that indicate the parent-child relationships between polygons | Yes | [docs](workers/properties/connections/parent_child_worker/PARENT_CHILD_WORKER.md) |
 
 ## Test / Sample Workers
 
@@ -108,8 +108,8 @@ Workers used for testing and demonstration -- not intended for production use.
 | Annulus Generator M1 |  |  |  | [docs](workers/annotations/annulus_generator_M1/ANNULUS_GENERATOR_M1.md) |
 | Random point | Creates random point annotations |  |  | [docs](workers/annotations/random_point/RANDOM_POINT.md) |
 | Random Point Annotation M1 |  |  |  | [docs](workers/annotations/random_point_annotation_M1/RANDOM_POINT_ANNOTATION_M1.md) |
-| Random squares | Generates random square polygon annotations within the image bounds. Useful for testing... |  | Yes | [docs](workers/annotations/random_squares/RANDOM_SQUARES.md) |
-| Sample interface | This is a sample interface worker that demonstrates all available interface types, tool... |  | Yes | [docs](workers/annotations/sample_interface/SAMPLE_INTERFACE.md) |
+| Random squares | Generates random square polygon annotations for testing |  | Yes | [docs](workers/annotations/random_squares/RANDOM_SQUARES.md) |
+| Sample interface | Demonstrates all interface types, messaging patterns, and batch mode |  | Yes | [docs](workers/annotations/sample_interface/SAMPLE_INTERFACE.md) |
 | Test Multiple Annotation |  |  |  | [docs](workers/annotations/test_multiple_annotation/TEST_MULTIPLE_ANNOTATION.md) |
 | Test Multiple Annotation M1 |  |  |  | [docs](workers/annotations/test_multiple_annotation_M1/TEST_MULTIPLE_ANNOTATION_M1.md) |
 

--- a/build_workers.sh
+++ b/build_workers.sh
@@ -49,8 +49,16 @@
 #   ./build_test_workers.sh --build-and-run-tests
 # =============================================================================
 
-# Limit the number of parallel builds to 1 to avoid memory issues
-export COMPOSE_PARALLEL_LIMIT=1
+# Limit the number of parallel builds to avoid running out of memory: the
+# conda-solve / apt-install heavy worker builds -- and especially the GPU/ML
+# CUDA/torch builds -- can each eat several GB, so building too many at once
+# OOMs the host. Default is 1, which is safe everywhere.
+#
+# This bites even a beefy EC2 GPU build instance: it too can't handle many
+# concurrent heavy builds. Bumping to 2-3 via the environment is the sweet spot
+# there (faster than 1 without OOMing); going much higher is not worth it:
+#   COMPOSE_PARALLEL_LIMIT=3 ./build_workers.sh
+export COMPOSE_PARALLEL_LIMIT="${COMPOSE_PARALLEL_LIMIT:-1}"
 
 # Detect architecture
 ARCH=$(uname -m)

--- a/generate_worker_docs.py
+++ b/generate_worker_docs.py
@@ -89,6 +89,7 @@ class WorkerInfo:
     worker_type: str          # "annotation" or "property"
     category: Optional[str] = None  # "blobs"/"points"/"lines"/"connections"
     description: Optional[str] = None
+    label_description: Optional[str] = None  # Docker `description` label (concise; preferred for the registry one-liner)
     interface_name: Optional[str] = None
     interface_category: Optional[str] = None
     annotation_shape: Optional[str] = None
@@ -108,8 +109,17 @@ class WorkerInfo:
 # ---------------------------------------------------------------------------
 
 def _strip_html(text: str) -> str:
-    """Remove HTML tags and normalise whitespace."""
-    return re.sub(r"<[^>]+>", "", text).strip()
+    """Remove HTML tags and normalise whitespace.
+
+    Tags are replaced with a space (not deleted) so adjacent block elements
+    like ``</p><p>`` or ``<br>`` don't fuse words/sentences (e.g. the
+    "z-slices.It" artifact). A trailing "Learn more" link label, left over
+    after stripping its ``<a>`` tag, is dropped.
+    """
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    text = re.sub(r"\s*\bLearn more\b\.?\s*$", "", text).strip()
+    return text
 
 
 def extract_docker_labels(dockerfile_path: Path) -> dict:
@@ -318,6 +328,7 @@ def discover_workers() -> list:
                 worker_type="annotation",
                 category=None,
                 description=desc or labels.get("description"),
+                label_description=labels.get("description"),
                 interface_name=labels.get("interfaceName"),
                 interface_category=labels.get("interfaceCategory"),
                 annotation_shape=labels.get("annotationShape"),
@@ -354,6 +365,7 @@ def discover_workers() -> list:
                     worker_type="property",
                     category=category_dir.name,
                     description=desc or labels.get("description"),
+                    label_description=labels.get("description"),
                     interface_name=labels.get("interfaceName"),
                     interface_category=labels.get("interfaceCategory"),
                     annotation_shape=labels.get("annotationShape"),
@@ -601,7 +613,7 @@ def generate_registry(workers: list) -> str:
 
     def _row_ann(w: WorkerInfo) -> str:
         display = w.interface_name or w.name.replace("_", " ").title()
-        desc = _strip_html(w.description or "")
+        desc = _strip_html(w.label_description or w.description or "")
         if len(desc) > 90:
             desc = desc[:87] + "..."
         gpu = "Yes" if w.has_gpu else ""
@@ -612,7 +624,7 @@ def generate_registry(workers: list) -> str:
 
     def _row_prop(w: WorkerInfo) -> str:
         display = w.interface_name or w.name.replace("_", " ").title()
-        desc = _strip_html(w.description or "")
+        desc = _strip_html(w.label_description or w.description or "")
         if len(desc) > 90:
             desc = desc[:87] + "..."
         tests = "Yes" if w.has_tests else ""

--- a/scripts/PUSH_WORKERS_TO_ECR.md
+++ b/scripts/PUSH_WORKERS_TO_ECR.md
@@ -1,0 +1,191 @@
+# Pushing Worker Images to AWS ECR
+
+`scripts/push_workers_to_ecr.sh` is the single script for building NimbusImage
+worker Docker images and pushing them to a private AWS ECR registry. Given
+valid AWS credentials, it:
+
+1. Discovers workers from the `workers/` tree.
+2. Cross-builds each for `linux/amd64` with `docker buildx`.
+3. Builds and pushes any base image the worker needs (see
+   [Base images](#base-images)), then redirects the worker's `FROM` to the
+   ECR copy.
+4. Pushes each worker under two tags: the short git SHA and `latest`.
+
+It is a **local, laptop-driven workflow** — run it after sourcing production
+AWS credentials. There is no CI job that pushes images.
+
+---
+
+## TL;DR
+
+```bash
+# 0. (macOS, once) install a modern bash
+brew install bash
+
+# 1. Auth — sets AWS keys + session token (region defaults to us-east-1)
+source ../AWSDeploy/aws_credentials_prod.sh
+
+# 2. See the exact worker names
+/opt/homebrew/bin/bash scripts/push_workers_to_ecr.sh --list
+
+# 3. Build & push one or more workers
+/opt/homebrew/bin/bash scripts/push_workers_to_ecr.sh blob_metrics_worker connect_timelapse
+
+# Reuse a base image already in ECR (skip the slow base rebuild)
+/opt/homebrew/bin/bash scripts/push_workers_to_ecr.sh --skip-base blob_metrics_worker
+
+# Preview the exact commands without running them
+/opt/homebrew/bin/bash scripts/push_workers_to_ecr.sh --dry-run --all
+```
+
+---
+
+## Prerequisites
+
+| Requirement | Notes |
+|---|---|
+| **bash 4+** | macOS ships bash 3.2. `brew install bash`, then invoke `/opt/homebrew/bin/bash scripts/push_workers_to_ecr.sh ...`. The script refuses to run on bash 3. |
+| **Docker + buildx** | Docker Desktop is fine. The script creates a `docker-container` buildx builder named `nimbus-ecr-builder` on first run. |
+| **AWS CLI v2** | Used for `sts get-caller-identity`, ECR login, and repo creation. |
+| **ECR permissions** | The credentials must allow `ecr:GetAuthorizationToken`, `ecr:CreateRepository`, `ecr:DescribeRepositories`, and push (`ecr:*` / PowerUser is simplest). |
+
+## Authentication
+
+Credentials come from the AWSDeploy repo's sourced env script:
+
+```bash
+source ../AWSDeploy/aws_credentials_prod.sh
+```
+
+This exports `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and
+`AWS_SESSION_TOKEN` (SSO short-lived creds). It does **not** set a region, so
+the script defaults to `us-east-1` (override with `--region` or `$AWS_REGION`).
+The account ID is read automatically from `aws sts get-caller-identity`.
+
+> **Gotcha — shells don't share env.** If you run the script from a different
+> shell/terminal than the one you sourced creds in, it won't see them. Source
+> the creds in the same shell, or re-source before each run.
+
+The current prod registry is account **`677276105390`**, region **`us-east-1`**.
+
+## Options
+
+```
+--all              Build and push every discovered worker (asks first)
+--list             Print every discovered worker name and exit
+--skip-base        Don't (re)build base images; assume they're already in ECR
+--region REGION    AWS region (default: $AWS_REGION or us-east-1)
+--prefix PREFIX    ECR repo prefix (default: nimbus)
+--platform PLAT    Build platform (default: linux/amd64)
+--no-cache         Disable the local buildx cache for this run
+--dry-run          Print actions but run nothing
+-y, --yes          Skip confirmation prompts (creating ECR repos, --all)
+-h, --help         Show usage
+```
+
+## Image naming / tags
+
+```
+<acct>.dkr.ecr.<region>.amazonaws.com/<prefix>/<category>/<worker>:<short-git-sha>
+<acct>.dkr.ecr.<region>.amazonaws.com/<prefix>/<category>/<worker>:latest
+```
+
+- `<category>` is `annotations` or `properties`.
+- `<prefix>` defaults to `nimbus`; base images go under `<prefix>/base/<base>`.
+- The SHA tag gets a `-dirty` suffix when the git working tree has uncommitted
+  changes, so you always know an image was built from clean source.
+- ECR repos are created on first push (confirmation prompt; `-y` to skip).
+  Repos are created with tag mutability `MUTABLE` and `scanOnPush=true`.
+
+## Base images
+
+Workers build `FROM nimbusimage/<base>:latest` (`worker-base`,
+`image-processing-base`, or `test-worker-base`). Those images are **not on any
+public registry**, and any copy on your machine is built for the **host
+architecture** (arm64 on Apple Silicon), so they can't satisfy an amd64
+cross-build.
+
+The script handles this automatically:
+
+1. Builds the needed base for the target platform from
+   `workers/base_docker_images/Dockerfile.<base>`.
+2. Pushes it to `<prefix>/base/<base>` in ECR.
+3. Redirects the worker's `FROM` to that ECR image with
+   `docker buildx --build-context nimbusimage/<base>:latest=docker-image://<ecr>/<prefix>/base/<base>:latest`
+   — **no worker Dockerfile edits required**.
+
+A base is built at most once per run. Use `--skip-base` on later runs to reuse
+a base already pushed to ECR (the base build is the slowest step on macOS).
+
+## Build context auto-detection
+
+Worker Dockerfiles in this repo are inconsistent about build context:
+
+- Most COPY repo-root-relative paths (e.g.
+  `COPY ./workers/<cat>/<name>/entrypoint.py /`) and need the **repo root** as
+  context.
+- A few (cellpose, stardist, random_point, …) COPY worker-dir-relative paths
+  (e.g. `COPY ./environment.yml /`) and need the **worker directory** as
+  context.
+
+The script auto-detects the correct context per worker by checking where each
+`COPY`/`ADD` source actually resolves on disk, so both layouts build correctly
+under `--all`. (This fixes the original limitation where everything was built
+from the repo root and worker-dir Dockerfiles failed.)
+
+## Worker categories — what builds where
+
+| Group | Base | Builds with this script? | Notes |
+|---|---|---|---|
+| Property/connection/connect workers | `nimbusimage/worker-base` | ✅ fast | Reuse the worker-base image. |
+| Image-processing workers (crop, histogram_matching, registration, …) | `nimbusimage/image-processing-base` | ✅ | Needs the image-processing base built once. |
+| Older "BASE_IMAGE" workers (random_point, line_length_worker, point_to_nearest_*_distance) | `ghcr.io/arjunrajlaboratory/base_x86_image` (public, default ARG) | ✅ | Pull a public x86 base, then `conda env update`. |
+| Self-contained `ubuntu:jammy` workers | none (apt + conda from scratch) | ✅ slow | Each builds everything from scratch; slow under emulation. |
+| **GPU / ML workers** (cellpose family, sam*, deepcell, stardist, condensatenet, deconwolf, cellori) | `nvidia/cuda:*` | ⚠️ **prefer native x86** | See below. |
+
+### What we deliberately do **not** push
+
+- **Test / sample workers** — `random_squares`, `sample_interface`,
+  `test_*`. These are dev/testing artifacts, not deployed.
+- **`_M1` variants** — `*_M1` Dockerfiles are CPU/Mac-development variants;
+  the production `Dockerfile` is what gets deployed.
+
+## Gotchas & specifics
+
+- **Worker names are directory names**, not docker-compose service names.
+  e.g. `blob_metrics_worker` (directory), not `blob_metrics` (compose service).
+  Always confirm with `--list`.
+- **macOS = QEMU emulation.** Building `linux/amd64` on Apple Silicon runs the
+  build under emulation. File-copy-only workers are fast; anything with a
+  conda solve / `apt install` is **much slower** (minutes to tens of minutes
+  each).
+- **GPU/ML workers should be built on a real x86_64 machine** (an EC2 amd64
+  instance, an amd64 CI runner, or a remote buildx builder) using
+  `build_machine_learning_workers.sh`. Emulating CUDA/torch builds on a Mac is
+  impractically slow and can fail. The script can *discover* them and detects
+  their context correctly, but native amd64 is strongly preferred for these.
+- **Piscis** has a non-standard `predict/` + `train/` layout and is not
+  discovered by this script; build it via `build_machine_learning_workers.sh`.
+- **Per-worker buildx cache** lives under `.cache/buildx/<worker>/` (and
+  `.cache/buildx/base-<base>/`) so reruns are fast; `--no-cache` disables it.
+
+## Verifying in the AWS console
+
+ECR → **Private registry → Repositories** (region `us-east-1`, account
+`677276105390`). Each `nimbus/...` repo lists its image tags, pushed time,
+size, and scan-on-push findings. Open an image digest to confirm the
+architecture is `linux/amd64`.
+
+Direct link (must be signed into the same account via SSO):
+`https://us-east-1.console.aws.amazon.com/ecr/private-registry/repositories?region=us-east-1`
+
+Or from the CLI:
+
+```bash
+aws ecr describe-repositories --region us-east-1 \
+  --query "repositories[?starts_with(repositoryName,'nimbus/')].repositoryName" --output text
+
+# confirm architecture of a pushed image
+docker buildx imagetools inspect \
+  677276105390.dkr.ecr.us-east-1.amazonaws.com/nimbus/properties/blob_metrics_worker:latest
+```

--- a/scripts/PUSH_WORKERS_TO_ECR.md
+++ b/scripts/PUSH_WORKERS_TO_ECR.md
@@ -145,10 +145,15 @@ from the repo root and worker-dir Dockerfiles failed.)
 
 ### What we deliberately do **not** push
 
+- **`_M1` variants** — `*_M1` Dockerfiles hardcode the **aarch64** Miniconda
+  installer (Apple-Silicon dev only) and cannot build for `linux/amd64`. They
+  are **excluded from discovery entirely** (not in `--list`, `--all`, or
+  by-name), so an amd64 `--all` run can complete.
 - **Test / sample workers** — `random_squares`, `sample_interface`,
-  `test_*`. These are dev/testing artifacts, not deployed.
-- **`_M1` variants** — `*_M1` Dockerfiles are CPU/Mac-development variants;
-  the production `Dockerfile` is what gets deployed.
+  `test_multiple_annotation`, `test_file_creation_worker`. These are
+  dev/testing artifacts; `--all` **skips them** (they're listed in the run
+  output). They still build on amd64, so you can push one **by explicit name**
+  if you ever need to.
 
 ## Gotchas & specifics
 

--- a/scripts/PUSH_WORKERS_TO_ECR.md
+++ b/scripts/PUSH_WORKERS_TO_ECR.md
@@ -74,6 +74,8 @@ The current prod registry is account **`677276105390`**, region **`us-east-1`**.
 --all              Build and push every discovered worker (asks first)
 --list             Print every discovered worker name and exit
 --skip-base        Don't (re)build base images; assume they're already in ECR
+--skip-ml          Exclude GPU/ML workers (FROM nvidia/cuda, incl. piscis)
+--only-ml          Build ONLY the GPU/ML workers (mutually exclusive w/ --skip-ml)
 --region REGION    AWS region (default: $AWS_REGION or us-east-1)
 --prefix PREFIX    ECR repo prefix (default: nimbus)
 --platform PLAT    Build platform (default: linux/amd64)
@@ -141,7 +143,7 @@ from the repo root and worker-dir Dockerfiles failed.)
 | Image-processing workers (crop, histogram_matching, registration, …) | `nimbusimage/image-processing-base` | ✅ | Needs the image-processing base built once. |
 | Older "BASE_IMAGE" workers (random_point, line_length_worker, point_to_nearest_*_distance) | `ghcr.io/arjunrajlaboratory/base_x86_image` (public, default ARG) | ✅ | Pull a public x86 base, then `conda env update`. |
 | Self-contained `ubuntu:jammy` workers | none (apt + conda from scratch) | ✅ slow | Each builds everything from scratch; slow under emulation. |
-| **GPU / ML workers** (cellpose family, sam*, deepcell, stardist, condensatenet, deconwolf, cellori) | `nvidia/cuda:*` | ⚠️ **prefer native x86** | See below. |
+| **GPU / ML workers** (cellpose family, sam*, deepcell, stardist, condensatenet, deconwolf, cellori, piscis) | `nvidia/cuda:*` (public) | ✅ but **prefer native x86** | No base redirect needed (public CUDA base). Cross-building under QEMU on a Mac is slow/fragile — build on a native amd64/GPU host, or `--skip-ml` for a laptop run. See below. |
 
 ### What we deliberately do **not** push
 
@@ -164,13 +166,18 @@ from the repo root and worker-dir Dockerfiles failed.)
   build under emulation. File-copy-only workers are fast; anything with a
   conda solve / `apt install` is **much slower** (minutes to tens of minutes
   each).
-- **GPU/ML workers should be built on a real x86_64 machine** (an EC2 amd64
-  instance, an amd64 CI runner, or a remote buildx builder) using
-  `build_machine_learning_workers.sh`. Emulating CUDA/torch builds on a Mac is
-  impractically slow and can fail. The script can *discover* them and detects
-  their context correctly, but native amd64 is strongly preferred for these.
-- **Piscis** has a non-standard `predict/` + `train/` layout and is not
-  discovered by this script; build it via `build_machine_learning_workers.sh`.
+- **GPU/ML workers are built and pushed by this script** (they build `FROM`
+  public `nvidia/cuda` images, so they need no base redirect). They *should*
+  be built on a real x86_64 machine (an EC2 amd64/GPU instance, an amd64 CI
+  runner, or a remote buildx builder): emulating CUDA/torch builds on a Mac is
+  impractically slow and can fail. On a Mac the script **warns** before
+  cross-building any GPU/ML worker under QEMU; pass `--skip-ml` to do a fast
+  standard-only run, or `--only-ml` on a GPU box. `build_machine_learning_workers.sh`
+  remains the **local-dev** build path (local tags, no ECR push).
+- **Piscis** has a non-standard `predict/` + `train/` layout (two images). It
+  **is** handled by this script as two pseudo-workers, `piscis_predict` and
+  `piscis_train` (both built with the piscis dir as context, matching its
+  `docker-compose.yaml`).
 - **Per-worker buildx cache** lives under `.cache/buildx/<worker>/` (and
   `.cache/buildx/base-<base>/`) so reruns are fast; `--no-cache` disables it.
 
@@ -181,6 +188,16 @@ not worth it for the GPU/ML workers. If you build on a **native `linux/amd64`
 machine**, there's no emulation: builds are fast, reliable, and GPU/ML workers
 build normally. The same `scripts/push_workers_to_ecr.sh` is used — `buildx`
 just builds natively because the host is already amd64.
+
+> **Tip — concurrency.** Local builds are throttled to one at a time
+> (`COMPOSE_PARALLEL_LIMIT=1` in `build_workers.sh`) because the conda/apt-heavy
+> worker builds — and especially the GPU/ML CUDA/torch builds — can OOM the host
+> when too many run at once. This bites **even an EC2 GPU build instance**, so
+> don't crank it high: **2–3 is the sweet spot** there (faster than 1 without
+> OOMing), e.g. `COMPOSE_PARALLEL_LIMIT=3 ./build_workers.sh`. Going much higher
+> is not worth it. (`push_workers_to_ecr.sh` itself builds workers serially
+> today; on a big amd64 box that loop is the obvious place to add bounded
+> parallelism.)
 
 ### A. On an existing amd64 Linux box
 
@@ -245,9 +262,14 @@ terminate it. This is the cleanest path for a full `--all` + GPU run.
    # buildx ships with current Docker; AWS CLI v2 is preinstalled on AL2023.
 
    git clone <this-repo> && cd ImageAnalysisProject
-   ./scripts/push_workers_to_ecr.sh --all          # standard workers
-   ./build_machine_learning_workers.sh             # GPU/ML workers (GPU host)
-   # then tag + push the ML images to nimbus/annotations/<worker> in ECR
+
+   # Builds + pushes EVERY worker, including the GPU/ML ones and piscis
+   # (as piscis_predict / piscis_train). Native amd64 => no emulation.
+   ./scripts/push_workers_to_ecr.sh --all
+
+   # Or split the run if you prefer:
+   #   ./scripts/push_workers_to_ecr.sh --skip-ml   # standard workers only
+   #   ./scripts/push_workers_to_ecr.sh --only-ml   # GPU/ML workers only (GPU box)
    ```
 
 4. **Terminate the instance** when done. Use a **spot instance** to keep the
@@ -257,11 +279,12 @@ terminate it. This is the cleanest path for a full `--all` + GPU run.
 > instance (instance type, IAM ECR role, user-data that clones the repo and
 > runs the build) so "spin up → build all → tear down" becomes one command.
 
-> **Note:** `push_workers_to_ecr.sh` currently covers the standard
-> (non-`nvidia/cuda`) workers. The GPU/ML workers are built by
-> `build_machine_learning_workers.sh`; pushing those to ECR is a manual
-> tag-and-push today (a future improvement is to teach one script to do both
-> on an amd64/GPU host).
+> **Note:** `push_workers_to_ecr.sh` now covers **all** workers it discovers —
+> standard, GPU/ML (`nvidia/cuda`), and piscis (`piscis_predict` /
+> `piscis_train`) — so a single `--all` run on a native amd64/GPU host builds
+> and pushes everything. `build_machine_learning_workers.sh` remains the
+> local-dev build path (local image tags, no ECR push); it is not needed for
+> the ECR workflow.
 
 ## Verifying in the AWS console
 

--- a/scripts/PUSH_WORKERS_TO_ECR.md
+++ b/scripts/PUSH_WORKERS_TO_ECR.md
@@ -169,6 +169,95 @@ from the repo root and worker-dir Dockerfiles failed.)
 - **Per-worker buildx cache** lives under `.cache/buildx/<worker>/` (and
   `.cache/buildx/base-<base>/`) so reruns are fast; `--no-cache` disables it.
 
+## Building on a native amd64 machine (recommended for bulk / ML)
+
+Cross-building on a Mac works but runs under QEMU emulation, which is slow and
+not worth it for the GPU/ML workers. If you build on a **native `linux/amd64`
+machine**, there's no emulation: builds are fast, reliable, and GPU/ML workers
+build normally. The same `scripts/push_workers_to_ecr.sh` is used — `buildx`
+just builds natively because the host is already amd64.
+
+### A. On an existing amd64 Linux box
+
+If you already have an amd64 Linux machine with Docker:
+
+```bash
+# Prereqs (most distros already have bash 5, git; install the rest):
+#   - Docker with buildx (Docker Engine 23+ bundles buildx)
+#   - AWS CLI v2
+#   - git
+# bash 4+ is standard on Linux, so just run the script directly.
+
+git clone <this-repo> && cd ImageAnalysisProject
+
+# Auth: either source the same creds script...
+source ../AWSDeploy/aws_credentials_prod.sh
+# ...or, if the box already has AWS creds configured (aws configure / env), skip that.
+
+# CPU / standard workers — native, fast:
+./scripts/push_workers_to_ecr.sh --all          # or name specific workers
+
+# GPU / ML workers — build + push via the ML build script on this amd64 box,
+# then tag/push to ECR (these are not handled by push_workers_to_ecr.sh):
+./build_machine_learning_workers.sh
+```
+
+> Because the host is amd64, the base-image builds are native too — still
+> pushed to `nimbus/base/<base>` and redirected via `--build-context` exactly
+> as on the Mac, just much faster. `--skip-base` still works once a base is in
+> ECR.
+
+### B. Spin up an ephemeral EC2 instance
+
+When you don't want to tie up a local machine — or want a GPU host for the ML
+workers — launch a throwaway amd64 EC2 instance, build everything, push, and
+terminate it. This is the cleanest path for a full `--all` + GPU run.
+
+1. **Launch an amd64 instance.**
+   - CPU-only workers: a compute/general instance, e.g. `c7i.4xlarge` /
+     `m7i.4xlarge` (more vCPUs = more parallel build throughput).
+   - GPU/ML workers: a GPU instance, e.g. `g5.2xlarge` or `g4dn.2xlarge`, with
+     a deep-learning AMI (or install the NVIDIA container toolkit). A GPU host
+     lets you also smoke-test the CUDA workers, not just build them.
+   - AMI: Amazon Linux 2023 or Ubuntu 22.04+. Give it ample EBS (ML images are
+     large — 100+ GB recommended).
+
+2. **Attach an IAM instance profile with ECR push permissions** (e.g.
+   `ecr:GetAuthorizationToken`, `ecr:CreateRepository`,
+   `ecr:DescribeRepositories`, `ecr:InitiateLayerUpload`,
+   `ecr:UploadLayerPart`, `ecr:CompleteLayerUpload`, `ecr:PutImage`,
+   `ecr:BatchCheckLayerAvailability`). With an instance role you **don't need
+   `aws_credentials_prod.sh`** — `aws ecr get-login-password` uses the role
+   automatically.
+
+3. **Install tooling and build:**
+
+   ```bash
+   # Amazon Linux 2023 example
+   sudo dnf install -y docker git
+   sudo systemctl enable --now docker
+   sudo usermod -aG docker "$USER" && newgrp docker
+   # buildx ships with current Docker; AWS CLI v2 is preinstalled on AL2023.
+
+   git clone <this-repo> && cd ImageAnalysisProject
+   ./scripts/push_workers_to_ecr.sh --all          # standard workers
+   ./build_machine_learning_workers.sh             # GPU/ML workers (GPU host)
+   # then tag + push the ML images to nimbus/annotations/<worker> in ECR
+   ```
+
+4. **Terminate the instance** when done. Use a **spot instance** to keep the
+   one-off cost low.
+
+> The Terraform in `../AWSDeploy/` is a natural place to template this build
+> instance (instance type, IAM ECR role, user-data that clones the repo and
+> runs the build) so "spin up → build all → tear down" becomes one command.
+
+> **Note:** `push_workers_to_ecr.sh` currently covers the standard
+> (non-`nvidia/cuda`) workers. The GPU/ML workers are built by
+> `build_machine_learning_workers.sh`; pushing those to ECR is a manual
+> tag-and-push today (a future improvement is to teach one script to do both
+> on an amd64/GPU host).
+
 ## Verifying in the AWS console
 
 ECR → **Private registry → Repositories** (region `us-east-1`, account

--- a/scripts/push_workers_to_ecr.sh
+++ b/scripts/push_workers_to_ecr.sh
@@ -45,6 +45,16 @@ declare -A BASE_DOCKERFILE=(
 )
 declare -A BUILT_BASES=()   # base name -> pushed image ref (built once per run)
 
+# Workers that --all skips: dev/test/sample artifacts that aren't deployed to
+# ECR. They still build fine on amd64, so they remain pushable by explicit name
+# if ever needed. (`*_M1` variants are excluded earlier, in discover_workers.)
+declare -a NON_DEPLOY_WORKERS=(
+    random_squares
+    sample_interface
+    test_multiple_annotation
+    test_file_creation_worker
+)
+
 REGION=""
 PREFIX=""
 PLATFORM=""
@@ -115,14 +125,20 @@ USAGE
 # Non-standard layouts (currently only piscis, which has predict/ and train/
 # subdirs and its own docker-compose.yaml) are skipped; build those with
 # build_machine_learning_workers.sh.
+#
+# `*_M1` worker directories are also skipped: those Dockerfiles hardcode the
+# aarch64 Miniconda installer for Apple Silicon development and cannot build
+# for linux/amd64 (the production target), so they are never pushed to ECR.
 discover_workers() {
     local f name
     while IFS= read -r f; do
         name="$(basename "$(dirname "$f")")"
+        case "$name" in *_M1) continue ;; esac   # arm64-only dev variant
         printf '%s\tannotations\t%s\n' "$name" "$f"
     done < <(find workers/annotations -mindepth 2 -maxdepth 2 -name Dockerfile -type f 2>/dev/null | sort)
     while IFS= read -r f; do
         name="$(basename "$(dirname "$f")")"
+        case "$name" in *_M1) continue ;; esac   # arm64-only dev variant
         printf '%s\tproperties\t%s\n' "$name" "$f"
     done < <(find workers/properties -mindepth 3 -maxdepth 3 -name Dockerfile -type f 2>/dev/null | sort)
 }
@@ -186,8 +202,22 @@ if [ "$ALL" = "1" ]; then
         err "--all is incompatible with positional worker names."
         exit 2
     fi
-    TARGETS=("${ALL_NAMES[@]}")
-    log "About to build and push ${#TARGETS[@]} workers (every discovered worker)."
+    declare -a _skipped=()
+    for n in "${ALL_NAMES[@]}"; do
+        _is_excluded=0
+        for d in "${NON_DEPLOY_WORKERS[@]}"; do
+            [ "$n" = "$d" ] && { _is_excluded=1; break; }
+        done
+        if [ "$_is_excluded" = "1" ]; then
+            _skipped+=("$n")
+        else
+            TARGETS+=("$n")
+        fi
+    done
+    if [ "${#_skipped[@]}" -gt 0 ]; then
+        log "Skipping ${#_skipped[@]} non-deployed worker(s) (push by name if needed): ${_skipped[*]}"
+    fi
+    log "About to build and push ${#TARGETS[@]} workers."
     if ! confirm "Proceed?"; then
         log "Aborted."
         exit 1
@@ -230,9 +260,13 @@ if ! SHA="$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null)"; then
     err "Not a git repository or no commits yet."
     exit 1
 fi
-if ! git -C "$REPO_ROOT" diff --quiet 2>/dev/null || \
-   ! git -C "$REPO_ROOT" diff --staged --quiet 2>/dev/null; then
-    warn "Working tree is dirty. Tagging SHA images as '${SHA}-dirty'."
+# `git status --porcelain` reports tracked modifications, staged changes, AND
+# untracked (non-.gitignored) files. Untracked files matter here because the
+# build context is usually the repo root, so a stray file can be COPYed into
+# an image while the tag still claims to match HEAD — breaking the `-dirty`
+# provenance guarantee. (.gitignored build artifacts like .cache/ are excluded.)
+if [ -n "$(git -C "$REPO_ROOT" status --porcelain 2>/dev/null)" ]; then
+    warn "Working tree is dirty (tracked changes and/or untracked files). Tagging SHA images as '${SHA}-dirty'."
     SHA="${SHA}-dirty"
 fi
 log "Git SHA tag: $SHA"

--- a/scripts/push_workers_to_ecr.sh
+++ b/scripts/push_workers_to_ecr.sh
@@ -4,7 +4,7 @@
 #
 # Build worker Docker images and push them to AWS ECR, one or more workers
 # at a time. Designed to be run from a developer laptop after sourcing AWS
-# credentials (e.g. `source aws_credentials_prod`).
+# credentials (e.g. `source ../AWSDeploy/aws_credentials_prod.sh`).
 #
 # Each push produces two tags per worker:
 #   <acct>.dkr.ecr.<region>.amazonaws.com/<prefix>/<category>/<worker>:<short-sha>
@@ -30,6 +30,21 @@ DEFAULT_PLATFORM="linux/amd64"
 BUILDER_NAME="nimbus-ecr-builder"
 CACHE_DIR="${REPO_ROOT}/.cache/buildx"
 
+# Worker images build `FROM nimbusimage/<base>:latest`. Those base images are
+# not on any public registry and are normally built locally for the host's
+# architecture, so they can't be used for an amd64 cross-build. We build the
+# needed base image(s) for the target platform, push them to ECR under
+# <prefix>/base/<base>, and redirect each worker's `FROM` to the ECR copy with
+# `docker buildx --build-context` (no worker Dockerfile edits required).
+#
+# Map: base image name (as it appears after `nimbusimage/` in FROM) -> Dockerfile.
+declare -A BASE_DOCKERFILE=(
+    [worker-base]="workers/base_docker_images/Dockerfile.worker_base"
+    [image-processing-base]="workers/base_docker_images/Dockerfile.image_processing_worker_base"
+    [test-worker-base]="workers/base_docker_images/Dockerfile.test_worker_base"
+)
+declare -A BUILT_BASES=()   # base name -> pushed image ref (built once per run)
+
 REGION=""
 PREFIX=""
 PLATFORM=""
@@ -38,6 +53,7 @@ DRY_RUN=0
 ALL=0
 LIST_ONLY=0
 ASSUME_YES=0
+SKIP_BASE=0
 declare -a REQUESTED=()
 
 log()  { printf '[push-ecr] %s\n' "$*"; }
@@ -71,14 +87,17 @@ Options:
   --prefix PREFIX    ECR repo prefix (default: nimbus)
   --platform PLAT    Build platform (default: linux/amd64)
   --no-cache         Disable the local buildx cache for this run
+  --skip-base        Don't (re)build base images; assume they're already in ECR
   --dry-run          Print actions but run nothing
   -y, --yes          Skip confirmation prompts (creating ECR repos, --all)
   -h, --help         Show this help
 
 Typical workflow:
-  source aws_credentials_prod
+  source ../AWSDeploy/aws_credentials_prod.sh
   ./scripts/push_workers_to_ecr.sh --list
   ./scripts/push_workers_to_ecr.sh blob_metrics_worker connect_timelapse
+
+Worker names are directory names (see --list), e.g. blob_metrics_worker.
 
 The script reads the AWS account ID from `aws sts get-caller-identity` and
 fails fast with a clear message if credentials aren't loaded. It only uses
@@ -119,6 +138,7 @@ while [ $# -gt 0 ]; do
         --platform)    PLATFORM="$2"; shift 2 ;;
         --platform=*)  PLATFORM="${1#*=}"; shift ;;
         --no-cache)    NO_CACHE="--no-cache"; shift ;;
+        --skip-base)   SKIP_BASE=1; shift ;;
         --dry-run)     DRY_RUN=1; shift ;;
         -y|--yes)      ASSUME_YES=1; shift ;;
         -h|--help)     print_usage; exit 0 ;;
@@ -262,6 +282,129 @@ ensure_repo() {
     log "Created repo '$repo'."
 }
 
+# Determine the build context a Dockerfile expects by checking where its
+# COPY/ADD sources actually resolve. Worker Dockerfiles in this repo are
+# inconsistent: most compose-built workers COPY repo-root-relative paths
+# (e.g. `./workers/<cat>/<name>/entrypoint.py`) and need the repo root as
+# context, while a few (cellpose, stardist, random_point, ...) COPY
+# worker-dir-relative paths (e.g. `./environment.yml`) and need the worker
+# directory as context. We pick the context under which every source exists.
+detect_context() {
+    local dfile="$1"
+    local wd; wd="$(dirname "$dfile")"
+    local -a srcs=()
+    local line
+    while IFS= read -r line; do
+        case "$line" in
+            [Cc][Oo][Pp][Yy][[:space:]]*|[Aa][Dd][Dd][[:space:]]*) : ;;
+            *) continue ;;
+        esac
+        case "$line" in *--from=*) continue ;; esac   # multi-stage, not from context
+        local -a toks=() args=()
+        read -r -a toks <<<"$line"
+        local i
+        for ((i = 1; i < ${#toks[@]}; i++)); do
+            case "${toks[$i]}" in
+                --*) continue ;;       # drop flags like --chown=/--chmod=
+                *)   args+=("${toks[$i]}") ;;
+            esac
+        done
+        local n=${#args[@]}
+        [ "$n" -lt 2 ] && continue     # need at least one source + dest
+        local j
+        for ((j = 0; j < n - 1; j++)); do
+            srcs+=("${args[$j]}")
+        done
+    done < "$dfile"
+
+    if [ "${#srcs[@]}" -eq 0 ]; then
+        printf '%s\n' "$REPO_ROOT"
+        return 0
+    fi
+
+    local all_root=1 all_wd=1 s p
+    for s in "${srcs[@]}"; do
+        p="${s#./}"
+        case "$p" in *[\*\?\[]*) p="$(dirname "$p")" ;; esac  # test dir for globs
+        [ -e "${REPO_ROOT}/${p}" ] || all_root=0
+        [ -e "${wd}/${p}" ]        || all_wd=0
+    done
+
+    if [ "$all_root" = "1" ]; then
+        printf '%s\n' "$REPO_ROOT"
+    elif [ "$all_wd" = "1" ]; then
+        printf '%s\n' "$REPO_ROOT/$wd"
+    else
+        warn "Ambiguous build context for ${dfile}; defaulting to repo root."
+        printf '%s\n' "$REPO_ROOT"
+    fi
+}
+
+# Echo the full `nimbusimage/<base>:<tag>` reference a worker builds FROM, or
+# nothing if the worker doesn't build from a known nimbusimage base.
+base_ref_for_worker() {
+    local dfile="$1"
+    grep -iE '^[[:space:]]*FROM[[:space:]]+nimbusimage/' "$dfile" \
+        | head -1 | awk '{print $2}'
+}
+
+# Build the given base image (by name, e.g. "worker-base") for the target
+# platform and push it to ECR. Cached per run via BUILT_BASES.
+ensure_base_image() {
+    local base="$1"
+    [ -n "${BUILT_BASES[$base]:-}" ] && return 0
+    local dfile="${BASE_DOCKERFILE[$base]:-}"
+    if [ -z "$dfile" ]; then
+        err "No Dockerfile known for base image 'nimbusimage/${base}'. Cannot redirect FROM."
+        return 1
+    fi
+    local repo="${PREFIX}/base/${base}"
+    local img="${REGISTRY}/${repo}:latest"
+
+    if [ "$SKIP_BASE" = "1" ]; then
+        log "Base image: assuming ${img} already exists (--skip-base)."
+        BUILT_BASES["$base"]="$img"
+        return 0
+    fi
+
+    log "Ensuring amd64 base image '${base}' -> ${img}"
+    ensure_repo "$repo" || return 1
+
+    local base_cache_dir="${CACHE_DIR}/base-${base}"
+    local -a cache_args=()
+    if [ -z "$NO_CACHE" ]; then
+        mkdir -p "$base_cache_dir"
+        cache_args+=(--cache-from "type=local,src=${base_cache_dir}")
+        cache_args+=(--cache-to   "type=local,dest=${base_cache_dir},mode=max")
+    fi
+    local -a no_cache_arg=()
+    [ -n "$NO_CACHE" ] && no_cache_arg=("$NO_CACHE")
+
+    if [ "$DRY_RUN" = "1" ]; then
+        printf '+ docker buildx build --builder %s --platform %s %s %s -f %s -t %s --push %s\n' \
+            "$BUILDER_NAME" "$PLATFORM" "${no_cache_arg[*]-}" "${cache_args[*]-}" \
+            "$dfile" "$img" "$REPO_ROOT"
+        BUILT_BASES["$base"]="$img"
+        return 0
+    fi
+
+    if docker buildx build \
+        --builder "$BUILDER_NAME" \
+        --platform "$PLATFORM" \
+        "${no_cache_arg[@]}" \
+        "${cache_args[@]}" \
+        -f "$dfile" \
+        -t "$img" \
+        --push \
+        "$REPO_ROOT"; then
+        BUILT_BASES["$base"]="$img"
+        log "Base image '${base}' pushed: ${img}"
+        return 0
+    fi
+    err "Failed to build/push base image '${base}'."
+    return 1
+}
+
 build_and_push_worker() {
     local name="$1"
     local cat="${CATEGORY_OF[$name]}"
@@ -271,10 +414,28 @@ build_and_push_worker() {
     local img_latest="${REGISTRY}/${repo}:latest"
     local worker_cache_dir="${CACHE_DIR}/${name}"
 
+    # Build context this worker's Dockerfile actually expects.
+    local ctx; ctx="$(detect_context "$dfile")"
+
+    # If the worker builds FROM a nimbusimage base, build+push that base for
+    # the target platform and redirect FROM to the ECR copy.
+    local from_ref base_name
+    from_ref="$(base_ref_for_worker "$dfile")"
+    local -a base_ctx_args=()
+    if [ -n "$from_ref" ]; then
+        base_name="${from_ref#nimbusimage/}"; base_name="${base_name%%:*}"
+        if [ -n "${BASE_DOCKERFILE[$base_name]:-}" ]; then
+            ensure_base_image "$base_name" || return 1
+            base_ctx_args+=(--build-context "${from_ref}=docker-image://${BUILT_BASES[$base_name]}")
+        fi
+    fi
+
     log "------------------------------------------------------------------"
     log "Worker:     ${name}"
     log "  Category: ${cat}"
     log "  Source:   ${dfile}"
+    log "  Context:  ${ctx}"
+    [ -n "$from_ref" ] && log "  Base:     ${from_ref} -> ${BUILT_BASES[$base_name]:-<unredirected>}"
     log "  Tags:     ${img_sha}"
     log "            ${img_latest}"
     log "------------------------------------------------------------------"
@@ -295,23 +456,25 @@ build_and_push_worker() {
     local attempt rc stderr_file
     for attempt in 1 2; do
         if [ "$DRY_RUN" = "1" ]; then
-            printf '+ docker buildx build --builder %s --platform %s %s %s -f %s -t %s -t %s --push .\n' \
+            printf '+ docker buildx build --builder %s --platform %s %s %s %s -f %s -t %s -t %s --push %s\n' \
                 "$BUILDER_NAME" "$PLATFORM" \
+                "${base_ctx_args[*]-}" \
                 "${no_cache_arg[*]-}" "${cache_args[*]-}" \
-                "$dfile" "$img_sha" "$img_latest"
+                "$dfile" "$img_sha" "$img_latest" "$ctx"
             return 0
         fi
         stderr_file="$(mktemp)"
         docker buildx build \
             --builder "$BUILDER_NAME" \
             --platform "$PLATFORM" \
+            "${base_ctx_args[@]}" \
             "${no_cache_arg[@]}" \
             "${cache_args[@]}" \
             -f "$dfile" \
             -t "$img_sha" \
             -t "$img_latest" \
             --push \
-            . 2> >(tee "$stderr_file" >&2)
+            "$ctx" 2> >(tee "$stderr_file" >&2)
         rc=$?
         if [ "$rc" -eq 0 ]; then
             rm -f "$stderr_file"

--- a/scripts/push_workers_to_ecr.sh
+++ b/scripts/push_workers_to_ecr.sh
@@ -10,6 +10,15 @@
 #   <acct>.dkr.ecr.<region>.amazonaws.com/<prefix>/<category>/<worker>:<short-sha>
 #   <acct>.dkr.ecr.<region>.amazonaws.com/<prefix>/<category>/<worker>:latest
 #
+# GPU/ML workers (cellpose family, sam/sam2 family, stardist, condensatenet,
+# deconwolf, deepcell, cellori, piscis) are covered too: they build FROM public
+# nvidia/cuda images, so they need no base redirect and push like any other
+# worker. They are slow/fragile to cross-build on a Mac under QEMU, so build
+# them on a native linux/amd64 host (an amd64/GPU EC2 instance). Use --skip-ml
+# for a fast standard-only run on a laptop, or --only-ml on a GPU box. piscis
+# (non-standard predict/ + train/ layout) is handled as two images:
+# piscis_predict and piscis_train, both built with the piscis dir as context.
+#
 # Run with --help for full usage. Run with --list to see available workers.
 
 set -uo pipefail
@@ -55,6 +64,16 @@ declare -a NON_DEPLOY_WORKERS=(
     test_file_creation_worker
 )
 
+# A few workers don't build with either the repo root or the Dockerfile's own
+# directory as context (so detect_context can't infer it). Pin the context
+# (repo-root-relative path) here. piscis is the case today: its predict/ and
+# train/ Dockerfiles COPY paths relative to the piscis dir (per its
+# docker-compose `context: .`), e.g. `./environment.yml`, `./predict/...`.
+declare -A CONTEXT_OVERRIDE=(
+    [piscis_predict]="workers/annotations/piscis"
+    [piscis_train]="workers/annotations/piscis"
+)
+
 REGION=""
 PREFIX=""
 PLATFORM=""
@@ -64,6 +83,8 @@ ALL=0
 LIST_ONLY=0
 ASSUME_YES=0
 SKIP_BASE=0
+SKIP_ML=0
+ONLY_ML=0
 declare -a REQUESTED=()
 
 log()  { printf '[push-ecr] %s\n' "$*"; }
@@ -98,6 +119,11 @@ Options:
   --platform PLAT    Build platform (default: linux/amd64)
   --no-cache         Disable the local buildx cache for this run
   --skip-base        Don't (re)build base images; assume they're already in ECR
+  --skip-ml          Exclude GPU/ML workers (FROM nvidia/cuda, incl. piscis).
+                     Handy for a fast standard-only run on a laptop.
+  --only-ml          Build ONLY the GPU/ML workers. Use on a native amd64/GPU
+                     host (e.g. an EC2 GPU instance). Mutually exclusive with
+                     --skip-ml.
   --dry-run          Print actions but run nothing
   -y, --yes          Skip confirmation prompts (creating ECR repos, --all)
   -h, --help         Show this help
@@ -108,6 +134,9 @@ Typical workflow:
   ./scripts/push_workers_to_ecr.sh blob_metrics_worker connect_timelapse
 
 Worker names are directory names (see --list), e.g. blob_metrics_worker.
+GPU/ML workers are included (cross-built under QEMU on a Mac, which is slow --
+prefer a native amd64/GPU host). piscis is split into piscis_predict and
+piscis_train.
 
 The script reads the AWS account ID from `aws sts get-caller-identity` and
 fails fast with a clear message if credentials aren't loaded. It only uses
@@ -122,11 +151,12 @@ USAGE
 #   workers/annotations/<name>/Dockerfile
 #   workers/properties/{blobs,points,lines,connections}/<name>/Dockerfile
 #
-# Non-standard layouts (currently only piscis, which has predict/ and train/
-# subdirs and its own docker-compose.yaml) are skipped; build those with
-# build_machine_learning_workers.sh.
+# piscis has a non-standard layout (predict/ + train/ subdirs, no top-level
+# Dockerfile, its own docker-compose.yaml) and produces TWO images. We emit it
+# as two pseudo-workers, piscis_predict and piscis_train, each with its own
+# Dockerfile; their build context is pinned via CONTEXT_OVERRIDE above.
 #
-# `*_M1` worker directories are also skipped: those Dockerfiles hardcode the
+# `*_M1` worker directories are skipped: those Dockerfiles hardcode the
 # aarch64 Miniconda installer for Apple Silicon development and cannot build
 # for linux/amd64 (the production target), so they are never pushed to ECR.
 discover_workers() {
@@ -141,6 +171,56 @@ discover_workers() {
         case "$name" in *_M1) continue ;; esac   # arm64-only dev variant
         printf '%s\tproperties\t%s\n' "$name" "$f"
     done < <(find workers/properties -mindepth 3 -maxdepth 3 -name Dockerfile -type f 2>/dev/null | sort)
+    # piscis: two images from one non-standard worker dir.
+    [ -f workers/annotations/piscis/predict/Dockerfile ] && \
+        printf '%s\tannotations\t%s\n' "piscis_predict" "workers/annotations/piscis/predict/Dockerfile"
+    [ -f workers/annotations/piscis/train/Dockerfile ] && \
+        printf '%s\tannotations\t%s\n' "piscis_train" "workers/annotations/piscis/train/Dockerfile"
+}
+
+# True if a worker's Dockerfile builds FROM an nvidia/cuda image, i.e. it's a
+# GPU/ML worker. Used for --skip-ml/--only-ml and the emulation warning.
+is_ml_worker() {
+    local dfile="$1"
+    grep -qiE '^[[:space:]]*FROM[[:space:]]+nvidia/cuda' "$dfile"
+}
+
+# Drop or keep GPU/ML workers in TARGETS per --skip-ml / --only-ml.
+filter_targets_by_ml() {
+    [ "$SKIP_ML" = "0" ] && [ "$ONLY_ML" = "0" ] && return 0
+    local -a keep=() drop=()
+    local n
+    for n in "${TARGETS[@]}"; do
+        if is_ml_worker "${DOCKERFILE_OF[$n]}"; then
+            if [ "$SKIP_ML" = "1" ]; then drop+=("$n"); else keep+=("$n"); fi
+        else
+            if [ "$ONLY_ML" = "1" ]; then drop+=("$n"); else keep+=("$n"); fi
+        fi
+    done
+    TARGETS=("${keep[@]}")
+    if [ "${#drop[@]}" -gt 0 ]; then
+        if [ "$ONLY_ML" = "1" ]; then
+            log "--only-ml: skipping ${#drop[@]} non-GPU/ML worker(s)."
+        else
+            log "--skip-ml: skipping ${#drop[@]} GPU/ML worker(s): ${drop[*]}"
+        fi
+    fi
+}
+
+# Warn loudly if we're about to cross-build GPU/ML workers under QEMU emulation
+# (amd64 target on a non-x86_64 host) -- these builds are slow and can fail.
+warn_if_emulating_ml() {
+    local target_arch="${PLATFORM##*/}"
+    local host_arch; host_arch="$(uname -m)"
+    case "$host_arch" in x86_64|amd64) return 0 ;; esac
+    [ "$target_arch" = "amd64" ] || return 0
+    local n ml=0
+    for n in "${TARGETS[@]}"; do
+        is_ml_worker "${DOCKERFILE_OF[$n]}" && ml=$((ml + 1))
+    done
+    [ "$ml" -eq 0 ] && return 0
+    warn "${ml} GPU/ML worker(s) will be cross-built for ${PLATFORM} on a ${host_arch} host (QEMU emulation)."
+    warn "This is slow and can fail. Prefer a native amd64/GPU host (EC2), or use --skip-ml here."
 }
 
 while [ $# -gt 0 ]; do
@@ -155,6 +235,8 @@ while [ $# -gt 0 ]; do
         --platform=*)  PLATFORM="${1#*=}"; shift ;;
         --no-cache)    NO_CACHE="--no-cache"; shift ;;
         --skip-base)   SKIP_BASE=1; shift ;;
+        --skip-ml)     SKIP_ML=1; shift ;;
+        --only-ml)     ONLY_ML=1; shift ;;
         --dry-run)     DRY_RUN=1; shift ;;
         -y|--yes)      ASSUME_YES=1; shift ;;
         -h|--help)     print_usage; exit 0 ;;
@@ -167,6 +249,11 @@ done
 REGION="${REGION:-$DEFAULT_REGION}"
 PREFIX="${PREFIX:-$DEFAULT_PREFIX}"
 PLATFORM="${PLATFORM:-$DEFAULT_PLATFORM}"
+
+if [ "$SKIP_ML" = "1" ] && [ "$ONLY_ML" = "1" ]; then
+    err "--skip-ml and --only-ml are mutually exclusive."
+    exit 2
+fi
 
 cd "$REPO_ROOT"
 
@@ -189,9 +276,10 @@ for line in "${WORKER_LIST[@]}"; do
 done
 
 if [ "$LIST_ONLY" = "1" ]; then
-    printf '%-50s %-12s %s\n' "WORKER" "CATEGORY" "DOCKERFILE"
+    printf '%-46s %-12s %-7s %s\n' "WORKER" "CATEGORY" "GPU/ML" "DOCKERFILE"
     for n in "${ALL_NAMES[@]}"; do
-        printf '%-50s %-12s %s\n' "$n" "${CATEGORY_OF[$n]}" "${DOCKERFILE_OF[$n]}"
+        _ml="-"; is_ml_worker "${DOCKERFILE_OF[$n]}" && _ml="yes"
+        printf '%-46s %-12s %-7s %s\n' "$n" "${CATEGORY_OF[$n]}" "$_ml" "${DOCKERFILE_OF[$n]}"
     done
     exit 0
 fi
@@ -217,11 +305,6 @@ if [ "$ALL" = "1" ]; then
     if [ "${#_skipped[@]}" -gt 0 ]; then
         log "Skipping ${#_skipped[@]} non-deployed worker(s) (push by name if needed): ${_skipped[*]}"
     fi
-    log "About to build and push ${#TARGETS[@]} workers."
-    if ! confirm "Proceed?"; then
-        log "Aborted."
-        exit 1
-    fi
 else
     if [ "${#REQUESTED[@]}" -eq 0 ]; then
         err "No workers specified. Use --list to see options or --all."
@@ -240,6 +323,25 @@ else
         exit 2
     fi
     TARGETS=("${REQUESTED[@]}")
+fi
+
+# Apply --skip-ml / --only-ml after the target list is assembled (works for
+# both --all and explicit names).
+filter_targets_by_ml
+
+if [ "${#TARGETS[@]}" -eq 0 ]; then
+    err "No workers left to build after filtering."
+    exit 1
+fi
+
+warn_if_emulating_ml
+
+if [ "$ALL" = "1" ]; then
+    log "About to build and push ${#TARGETS[@]} worker(s)."
+    if ! confirm "Proceed?"; then
+        log "Aborted."
+        exit 1
+    fi
 fi
 
 for tool in docker aws git; do
@@ -454,8 +556,14 @@ build_and_push_worker() {
     local img_latest="${REGISTRY}/${repo}:latest"
     local worker_cache_dir="${CACHE_DIR}/${name}"
 
-    # Build context this worker's Dockerfile actually expects.
-    local ctx; ctx="$(detect_context "$dfile")"
+    # Build context this worker's Dockerfile actually expects. A pinned
+    # CONTEXT_OVERRIDE (e.g. piscis) wins; otherwise infer it from COPY sources.
+    local ctx
+    if [ -n "${CONTEXT_OVERRIDE[$name]:-}" ]; then
+        ctx="${REPO_ROOT}/${CONTEXT_OVERRIDE[$name]}"
+    else
+        ctx="$(detect_context "$dfile")"
+    fi
 
     # If the worker builds FROM a nimbusimage base, build+push that base for
     # the target platform and redirect FROM to the ECR copy.
@@ -539,6 +647,12 @@ declare -a SUCCESS=()
 declare -a FAILURE=()
 START_TS=$SECONDS
 
+# Workers are built one at a time (serial) so build memory stays bounded and
+# the logs / auth-retry stay easy to follow. On a high-memory native amd64 host
+# (e.g. an EC2 build box) this is the slow part of a full --all run, and
+# parallelizing it (e.g. background jobs with a bounded fan-out, or `xargs -P`)
+# is a safe future optimization there. See also COMPOSE_PARALLEL_LIMIT in
+# build_workers.sh for the analogous knob on the compose-based local builds.
 for name in "${TARGETS[@]}"; do
     worker_start=$SECONDS
     if build_and_push_worker "$name"; then

--- a/scripts/push_workers_to_ecr.sh
+++ b/scripts/push_workers_to_ecr.sh
@@ -142,6 +142,9 @@ The script reads the AWS account ID from `aws sts get-caller-identity` and
 fails fast with a clear message if credentials aren't loaded. It only uses
 production Dockerfiles (the Dockerfile_M1 variants are skipped).
 
+Set $ECR_REGISTRY to override the target registry URL (default: derived from
+the authenticated account + region).
+
 USAGE
 }
 
@@ -356,7 +359,14 @@ if ! ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text 2>/
 fi
 log "AWS account: $ACCOUNT_ID  region: $REGION"
 
-REGISTRY="${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com"
+# Registry URL. Honor an explicit $ECR_REGISTRY (the shared env-var contract
+# with the AWSDeploy consume side -- see that repo's
+# doc/Build_and_Push_Worker_Images_to_ECR.md); otherwise derive it from the
+# authenticated account + region (which also respects --region).
+REGISTRY="${ECR_REGISTRY:-${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com}"
+if [ -n "${ECR_REGISTRY:-}" ]; then
+    log "Registry:    $REGISTRY (from \$ECR_REGISTRY)"
+fi
 
 if ! SHA="$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null)"; then
     err "Not a git repository or no commits yet."

--- a/scripts/push_workers_to_ecr.sh
+++ b/scripts/push_workers_to_ecr.sh
@@ -273,13 +273,17 @@ ensure_repo() {
         err "Skipping '$repo' (no repo)."
         return 1
     fi
-    aws ecr create-repository \
+    if aws ecr create-repository \
         --region "$REGION" \
         --repository-name "$repo" \
         --image-tag-mutability MUTABLE \
         --image-scanning-configuration scanOnPush=true \
-        >/dev/null
-    log "Created repo '$repo'."
+        >/dev/null 2>&1; then
+        log "Created repo '$repo'."
+    else
+        err "Failed to create ECR repo '$repo' (check name constraints / permissions)."
+        return 1
+    fi
 }
 
 # Determine the build context a Dockerfile expects by checking where its
@@ -409,7 +413,9 @@ build_and_push_worker() {
     local name="$1"
     local cat="${CATEGORY_OF[$name]}"
     local dfile="${DOCKERFILE_OF[$name]}"
-    local repo="${PREFIX}/${cat}/${name}"
+    # ECR repo names and Docker image tags must be lowercase; some worker
+    # directory names are not (e.g. blob_point_count_3D_..., the *_M1 variants).
+    local repo="${PREFIX}/${cat}/${name,,}"
     local img_sha="${REGISTRY}/${repo}:${SHA}"
     local img_latest="${REGISTRY}/${repo}:latest"
     local worker_cache_dir="${CACHE_DIR}/${name}"

--- a/scripts/push_workers_to_ecr.sh
+++ b/scripts/push_workers_to_ecr.sh
@@ -1,0 +1,376 @@
+#!/usr/bin/env bash
+#
+# push_workers_to_ecr.sh
+#
+# Build worker Docker images and push them to AWS ECR, one or more workers
+# at a time. Designed to be run from a developer laptop after sourcing AWS
+# credentials (e.g. `source aws_credentials_prod`).
+#
+# Each push produces two tags per worker:
+#   <acct>.dkr.ecr.<region>.amazonaws.com/<prefix>/<category>/<worker>:<short-sha>
+#   <acct>.dkr.ecr.<region>.amazonaws.com/<prefix>/<category>/<worker>:latest
+#
+# Run with --help for full usage. Run with --list to see available workers.
+
+set -uo pipefail
+
+if [ -z "${BASH_VERSION:-}" ] || [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
+    echo "ERROR: This script needs bash 4 or newer (uses 'mapfile' and associative arrays)." >&2
+    echo "       Detected: ${BASH_VERSION:-unknown}" >&2
+    echo "       On macOS: 'brew install bash' and re-run with /opt/homebrew/bin/bash (or /usr/local/bin/bash)." >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." >/dev/null 2>&1 && pwd)"
+
+DEFAULT_REGION="${AWS_REGION:-us-east-1}"
+DEFAULT_PREFIX="nimbus"
+DEFAULT_PLATFORM="linux/amd64"
+BUILDER_NAME="nimbus-ecr-builder"
+CACHE_DIR="${REPO_ROOT}/.cache/buildx"
+
+REGION=""
+PREFIX=""
+PLATFORM=""
+NO_CACHE=""
+DRY_RUN=0
+ALL=0
+LIST_ONLY=0
+ASSUME_YES=0
+declare -a REQUESTED=()
+
+log()  { printf '[push-ecr] %s\n' "$*"; }
+err()  { printf '[push-ecr] ERROR: %s\n' "$*" >&2; }
+warn() { printf '[push-ecr] WARN:  %s\n' "$*" >&2; }
+
+confirm() {
+    [ "$ASSUME_YES" = "1" ] && return 0
+    local prompt="$1 [y/N] "
+    local answer=""
+    read -r -p "$prompt" answer || return 1
+    case "$answer" in
+        y|Y|yes|YES) return 0 ;;
+        *)           return 1 ;;
+    esac
+}
+
+print_usage() {
+    cat <<'USAGE'
+Usage:
+  push_workers_to_ecr.sh [OPTIONS] WORKER [WORKER ...]
+  push_workers_to_ecr.sh --all [OPTIONS]
+  push_workers_to_ecr.sh --list
+
+Build and push worker Docker images to AWS ECR.
+
+Options:
+  --all              Build and push every discovered worker (asks first)
+  --list             Print every discovered worker name and exit
+  --region REGION    AWS region (default: $AWS_REGION or us-east-1)
+  --prefix PREFIX    ECR repo prefix (default: nimbus)
+  --platform PLAT    Build platform (default: linux/amd64)
+  --no-cache         Disable the local buildx cache for this run
+  --dry-run          Print actions but run nothing
+  -y, --yes          Skip confirmation prompts (creating ECR repos, --all)
+  -h, --help         Show this help
+
+Typical workflow:
+  source aws_credentials_prod
+  ./scripts/push_workers_to_ecr.sh --list
+  ./scripts/push_workers_to_ecr.sh blob_metrics_worker connect_timelapse
+
+The script reads the AWS account ID from `aws sts get-caller-identity` and
+fails fast with a clear message if credentials aren't loaded. It only uses
+production Dockerfiles (the Dockerfile_M1 variants are skipped).
+
+USAGE
+}
+
+# Output lines: "<worker_name>\t<category>\t<dockerfile_path>"
+#
+# We deliberately look only at the standard layouts:
+#   workers/annotations/<name>/Dockerfile
+#   workers/properties/{blobs,points,lines,connections}/<name>/Dockerfile
+#
+# Non-standard layouts (currently only piscis, which has predict/ and train/
+# subdirs and its own docker-compose.yaml) are skipped; build those with
+# build_machine_learning_workers.sh.
+discover_workers() {
+    local f name
+    while IFS= read -r f; do
+        name="$(basename "$(dirname "$f")")"
+        printf '%s\tannotations\t%s\n' "$name" "$f"
+    done < <(find workers/annotations -mindepth 2 -maxdepth 2 -name Dockerfile -type f 2>/dev/null | sort)
+    while IFS= read -r f; do
+        name="$(basename "$(dirname "$f")")"
+        printf '%s\tproperties\t%s\n' "$name" "$f"
+    done < <(find workers/properties -mindepth 3 -maxdepth 3 -name Dockerfile -type f 2>/dev/null | sort)
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --all)         ALL=1; shift ;;
+        --list)        LIST_ONLY=1; shift ;;
+        --region)      REGION="$2"; shift 2 ;;
+        --region=*)    REGION="${1#*=}"; shift ;;
+        --prefix)      PREFIX="$2"; shift 2 ;;
+        --prefix=*)    PREFIX="${1#*=}"; shift ;;
+        --platform)    PLATFORM="$2"; shift 2 ;;
+        --platform=*)  PLATFORM="${1#*=}"; shift ;;
+        --no-cache)    NO_CACHE="--no-cache"; shift ;;
+        --dry-run)     DRY_RUN=1; shift ;;
+        -y|--yes)      ASSUME_YES=1; shift ;;
+        -h|--help)     print_usage; exit 0 ;;
+        --)            shift; while [ $# -gt 0 ]; do REQUESTED+=("$1"); shift; done ;;
+        -*)            err "Unknown option: $1"; print_usage; exit 2 ;;
+        *)             REQUESTED+=("$1"); shift ;;
+    esac
+done
+
+REGION="${REGION:-$DEFAULT_REGION}"
+PREFIX="${PREFIX:-$DEFAULT_PREFIX}"
+PLATFORM="${PLATFORM:-$DEFAULT_PLATFORM}"
+
+cd "$REPO_ROOT"
+
+declare -a WORKER_LIST
+mapfile -t WORKER_LIST < <(discover_workers)
+
+if [ "${#WORKER_LIST[@]}" -eq 0 ]; then
+    err "No workers found under workers/. Are you in the repo root?"
+    exit 1
+fi
+
+declare -A CATEGORY_OF
+declare -A DOCKERFILE_OF
+declare -a ALL_NAMES=()
+for line in "${WORKER_LIST[@]}"; do
+    IFS=$'\t' read -r _name _cat _dfile <<<"$line"
+    CATEGORY_OF["$_name"]="$_cat"
+    DOCKERFILE_OF["$_name"]="$_dfile"
+    ALL_NAMES+=("$_name")
+done
+
+if [ "$LIST_ONLY" = "1" ]; then
+    printf '%-50s %-12s %s\n' "WORKER" "CATEGORY" "DOCKERFILE"
+    for n in "${ALL_NAMES[@]}"; do
+        printf '%-50s %-12s %s\n' "$n" "${CATEGORY_OF[$n]}" "${DOCKERFILE_OF[$n]}"
+    done
+    exit 0
+fi
+
+declare -a TARGETS=()
+if [ "$ALL" = "1" ]; then
+    if [ "${#REQUESTED[@]}" -gt 0 ]; then
+        err "--all is incompatible with positional worker names."
+        exit 2
+    fi
+    TARGETS=("${ALL_NAMES[@]}")
+    log "About to build and push ${#TARGETS[@]} workers (every discovered worker)."
+    if ! confirm "Proceed?"; then
+        log "Aborted."
+        exit 1
+    fi
+else
+    if [ "${#REQUESTED[@]}" -eq 0 ]; then
+        err "No workers specified. Use --list to see options or --all."
+        print_usage
+        exit 2
+    fi
+    declare -a _missing=()
+    for n in "${REQUESTED[@]}"; do
+        if [ -z "${DOCKERFILE_OF[$n]:-}" ]; then
+            _missing+=("$n")
+        fi
+    done
+    if [ "${#_missing[@]}" -gt 0 ]; then
+        err "Unknown worker(s): ${_missing[*]}"
+        err "Run with --list to see available worker names."
+        exit 2
+    fi
+    TARGETS=("${REQUESTED[@]}")
+fi
+
+for tool in docker aws git; do
+    command -v "$tool" >/dev/null 2>&1 || { err "Required tool '$tool' not found on PATH."; exit 1; }
+done
+
+log "Verifying AWS credentials..."
+if ! ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text 2>/dev/null)"; then
+    err "aws sts get-caller-identity failed."
+    err "Source your AWS credentials first (e.g. 'source aws_credentials_prod')."
+    exit 1
+fi
+log "AWS account: $ACCOUNT_ID  region: $REGION"
+
+REGISTRY="${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com"
+
+if ! SHA="$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null)"; then
+    err "Not a git repository or no commits yet."
+    exit 1
+fi
+if ! git -C "$REPO_ROOT" diff --quiet 2>/dev/null || \
+   ! git -C "$REPO_ROOT" diff --staged --quiet 2>/dev/null; then
+    warn "Working tree is dirty. Tagging SHA images as '${SHA}-dirty'."
+    SHA="${SHA}-dirty"
+fi
+log "Git SHA tag: $SHA"
+
+ensure_builder() {
+    if ! docker buildx inspect "$BUILDER_NAME" >/dev/null 2>&1; then
+        log "Creating buildx builder '$BUILDER_NAME'..."
+        if [ "$DRY_RUN" = "1" ]; then
+            printf '+ docker buildx create --name %s --driver docker-container --bootstrap\n' "$BUILDER_NAME"
+        else
+            docker buildx create --name "$BUILDER_NAME" --driver docker-container --bootstrap >/dev/null
+        fi
+    fi
+}
+
+ecr_login() {
+    log "Logging in to ECR registry ${REGISTRY}"
+    if [ "$DRY_RUN" = "1" ]; then
+        printf '+ aws ecr get-login-password --region %s | docker login --username AWS --password-stdin %s\n' \
+            "$REGION" "$REGISTRY"
+        return 0
+    fi
+    aws ecr get-login-password --region "$REGION" \
+        | docker login --username AWS --password-stdin "$REGISTRY" >/dev/null
+}
+
+ensure_repo() {
+    local repo="$1"
+    if aws ecr describe-repositories --region "$REGION" --repository-names "$repo" >/dev/null 2>&1; then
+        return 0
+    fi
+    log "ECR repo '$repo' does not exist."
+    if [ "$DRY_RUN" = "1" ]; then
+        printf '+ aws ecr create-repository --region %s --repository-name %s\n' "$REGION" "$repo"
+        return 0
+    fi
+    if ! confirm "Create ECR repo '${repo}' now?"; then
+        err "Skipping '$repo' (no repo)."
+        return 1
+    fi
+    aws ecr create-repository \
+        --region "$REGION" \
+        --repository-name "$repo" \
+        --image-tag-mutability MUTABLE \
+        --image-scanning-configuration scanOnPush=true \
+        >/dev/null
+    log "Created repo '$repo'."
+}
+
+build_and_push_worker() {
+    local name="$1"
+    local cat="${CATEGORY_OF[$name]}"
+    local dfile="${DOCKERFILE_OF[$name]}"
+    local repo="${PREFIX}/${cat}/${name}"
+    local img_sha="${REGISTRY}/${repo}:${SHA}"
+    local img_latest="${REGISTRY}/${repo}:latest"
+    local worker_cache_dir="${CACHE_DIR}/${name}"
+
+    log "------------------------------------------------------------------"
+    log "Worker:     ${name}"
+    log "  Category: ${cat}"
+    log "  Source:   ${dfile}"
+    log "  Tags:     ${img_sha}"
+    log "            ${img_latest}"
+    log "------------------------------------------------------------------"
+
+    ensure_repo "$repo" || return 1
+
+    mkdir -p "$worker_cache_dir"
+
+    local -a cache_args=()
+    if [ -z "$NO_CACHE" ]; then
+        cache_args+=(--cache-from "type=local,src=${worker_cache_dir}")
+        cache_args+=(--cache-to   "type=local,dest=${worker_cache_dir},mode=max")
+    fi
+
+    local -a no_cache_arg=()
+    [ -n "$NO_CACHE" ] && no_cache_arg=("$NO_CACHE")
+
+    local attempt rc stderr_file
+    for attempt in 1 2; do
+        if [ "$DRY_RUN" = "1" ]; then
+            printf '+ docker buildx build --builder %s --platform %s %s %s -f %s -t %s -t %s --push .\n' \
+                "$BUILDER_NAME" "$PLATFORM" \
+                "${no_cache_arg[*]-}" "${cache_args[*]-}" \
+                "$dfile" "$img_sha" "$img_latest"
+            return 0
+        fi
+        stderr_file="$(mktemp)"
+        docker buildx build \
+            --builder "$BUILDER_NAME" \
+            --platform "$PLATFORM" \
+            "${no_cache_arg[@]}" \
+            "${cache_args[@]}" \
+            -f "$dfile" \
+            -t "$img_sha" \
+            -t "$img_latest" \
+            --push \
+            . 2> >(tee "$stderr_file" >&2)
+        rc=$?
+        if [ "$rc" -eq 0 ]; then
+            rm -f "$stderr_file"
+            return 0
+        fi
+        if [ "$attempt" -eq 1 ] && grep -qiE 'unauthorized|denied|no basic auth credentials|authentication required' "$stderr_file"; then
+            warn "Push failed with an auth error. Re-logging in to ECR and retrying once."
+            rm -f "$stderr_file"
+            ecr_login || { err "ECR re-login failed."; return 1; }
+            continue
+        fi
+        rm -f "$stderr_file"
+        err "Build/push failed for '$name' (exit $rc)."
+        return 1
+    done
+}
+
+ensure_builder
+ecr_login
+
+declare -a SUCCESS=()
+declare -a FAILURE=()
+START_TS=$SECONDS
+
+for name in "${TARGETS[@]}"; do
+    worker_start=$SECONDS
+    if build_and_push_worker "$name"; then
+        SUCCESS+=("$(printf '%s (%s, %ds)' "$name" "${CATEGORY_OF[$name]}" $((SECONDS-worker_start)))")
+    else
+        FAILURE+=("$name")
+    fi
+done
+
+TOTAL=$((SECONDS - START_TS))
+
+log ""
+log "=================================================================="
+log "Summary"
+log "=================================================================="
+log "Registry: ${REGISTRY}"
+log "Prefix:   ${PREFIX}"
+log "SHA tag:  ${SHA}"
+log "Targets:  ${#TARGETS[@]}"
+log "Pushed:   ${#SUCCESS[@]}"
+log "Failed:   ${#FAILURE[@]}"
+log "Elapsed:  ${TOTAL}s"
+
+if [ "${#SUCCESS[@]}" -gt 0 ]; then
+    log ""
+    log "Pushed:"
+    for s in "${SUCCESS[@]}"; do
+        log "  - $s"
+    done
+fi
+if [ "${#FAILURE[@]}" -gt 0 ]; then
+    log ""
+    err "Failed:"
+    for f in "${FAILURE[@]}"; do
+        err "  - $f"
+    done
+    exit 1
+fi

--- a/todo/TODO_REGISTRY.md
+++ b/todo/TODO_REGISTRY.md
@@ -13,6 +13,7 @@ Master index of deferred work, technical debt, and future improvements for the I
 | ID | Title | Status | Priority | File | Related PR |
 |----|-------|--------|----------|------|------------|
 | TODO-001 | ML worker build optimization (mamba + shared base images) | Deferred | Medium | [ml-worker-build-optimization.md](ml-worker-build-optimization.md) | [#132](https://github.com/arjunrajlaboratory/ImageAnalysisProject/pull/132) |
+| TODO-002 | Pull-first / build-fallback for worker images from ECR | Deferred | Low | [ecr-pull-first-build-fallback.md](ecr-pull-first-build-fallback.md) | [#141](https://github.com/arjunrajlaboratory/ImageAnalysisProject/pull/141) |
 
 ## Completed TODOs
 

--- a/todo/ecr-pull-first-build-fallback.md
+++ b/todo/ecr-pull-first-build-fallback.md
@@ -1,0 +1,70 @@
+# TODO-002: Pull-first / build-fallback for worker images from ECR
+
+**Status:** Deferred
+**Priority:** Low
+**Related PR:** [#141 — push_workers_to_ecr.sh (produce side)](https://github.com/arjunrajlaboratory/ImageAnalysisProject/pull/141)
+**Companion (consume side):** AWSDeploy PR #54 — Celery worker EC2 instances pull prebuilt worker images from ECR at startup instead of rebuilding from source.
+
+## Summary
+
+The "worker images on ECR" workflow has two halves:
+
+- **Produce** (this repo, PR #141, done): `scripts/push_workers_to_ecr.sh` builds each worker for `linux/amd64` and pushes it to `nimbus/<category>/<worker>` in ECR. It honors the shared `$ECR_REGISTRY` env-var contract (commit `48d13a3`).
+- **Consume** (AWSDeploy PR #54): Celery GPU workers get a read-only ECR IAM role and `docker login` to ECR at boot, then their cloud-init clones this repo and runs the build scripts.
+
+The deferred piece is the link between them: make the **build scripts pull-first** so that when a prebuilt image exists in ECR, cloud-init pulls it instead of rebuilding from source (the whole point of the consume side). Until this lands, AWSDeploy PR #54 is a harmless no-op — workers still rebuild.
+
+## What's done
+
+- `push_workers_to_ecr.sh` resolves the registry from `$ECR_REGISTRY` (default: derived from the authenticated account + region). No new flag; no behavior change when unset. The full env-var contract is documented in AWSDeploy's `doc/Build_and_Push_Worker_Images_to_ECR.md` (do **not** duplicate that doc here).
+
+## What's deferred (the work)
+
+In `build_workers.sh` and `build_machine_learning_workers.sh` (the scripts AWSDeploy's Celery cloud-init clones and invokes), implement per-worker pull-first / build-fallback:
+
+- If `$ECR_REGISTRY` is set and `docker pull "$ECR_REGISTRY/nimbus/<category>/<worker>:latest"` succeeds, `docker tag` it to the local tag Girder's worker discovery expects, and **skip** the build for that worker.
+- Otherwise fall through to the existing build. **Behavior must be unchanged when `$ECR_REGISTRY` is unset** (strict additive change).
+- Treat ML/GPU workers identically to standard workers — no separate code path.
+- Reuse the existing source of truth for the worker list + category mapping rather than re-enumerating workers in a second place.
+
+## Blockers / open questions (resolve before writing this)
+
+These are why it was deferred rather than done as a quick additive change:
+
+1. **What local image tag does Girder/Celery worker discovery actually expect?**
+   This is the `docker tag` target. Getting it wrong silently breaks worker
+   discovery, so it must be confirmed against the running system / how workers
+   are registered — not guessed.
+
+2. **The names don't line up across the scripts.** There is no single existing
+   source of truth that spans all four naming spaces:
+
+   | Thing | Example |
+   |---|---|
+   | Worker **directory** (what `push_workers_to_ecr.sh` enumerates) | `cellpose`, `blob_metrics_worker` |
+   | **ECR repo** the push script creates | `nimbus/annotations/cellpose`, `nimbus/properties/blob_metrics_worker` |
+   | Local tag the **ML build script** produces | `annotations/cellpose_worker:latest` (note the `_worker` suffix) |
+   | `build_workers.sh` **compose service** name | `blob_metrics` (≠ dir `blob_metrics_worker`), `connect_time_lapse` (≠ dir `connect_timelapse`) |
+
+   A correct pull-first needs an explicit mapping between these.
+
+3. **`build_workers.sh` builds everything in one `docker compose build`**, not
+   per-worker, so per-worker pull-first requires restructuring it into a
+   per-service loop (or a pre-pass that pulls+tags available images, then tells
+   compose to skip those). `build_machine_learning_workers.sh` is already
+   per-worker (`docker build ... -t ...`), so the fallback is easier there.
+
+## Verification plan (when implemented)
+
+- `bash -n` each modified script.
+- `./scripts/push_workers_to_ecr.sh --dry-run --all` still renders the expected registry URLs.
+- With `$ECR_REGISTRY` **unset**, a build script still rebuilds from source (no regression).
+- With `$ECR_REGISTRY` set and a worker image present in ECR, that worker is pulled + tagged, not rebuilt.
+
+## Notes
+
+- No new shell/Python dependencies — AWS CLI + Docker are already required.
+- Keep it targeted/additive; don't refactor unrelated parts of the build scripts.
+- The originating spec (from the AWSDeploy agent) wanted a single PR titled e.g.
+  "Honor $ECR_REGISTRY; pull prebuilt worker images when available" covering
+  both the `$ECR_REGISTRY` change (done, `48d13a3`) and this pull-first work.


### PR DESCRIPTION
## Summary

`scripts/push_workers_to_ecr.sh` builds NimbusImage worker Docker images for
`linux/amd64` and pushes them to AWS ECR. Each worker gets two tags (short git
SHA + `latest`); needed base images are built for amd64 and each worker's
`FROM` is redirected to the ECR copy via `docker buildx --build-context` (no
Dockerfile edits). Full reference: [`scripts/PUSH_WORKERS_TO_ECR.md`](scripts/PUSH_WORKERS_TO_ECR.md).

## Where to run it

Two supported paths:

- **Laptop (macOS).** Cross-builds `linux/amd64` under QEMU. Fine for standard
  CPU workers; needs bash 4+ (`brew install bash`, run with `/opt/homebrew/bin/bash`).
  GPU/ML workers are slow/fragile under emulation — use `--skip-ml` for a quick
  standard-only run.
- **Native amd64 / EC2 (recommended for bulk + GPU/ML).** On a native amd64 (or
  amd64/GPU) host there is no emulation — builds are fast and GPU/ML workers
  build normally. Spin up an ephemeral instance with an IAM instance profile
  that has ECR push permissions (so `aws_credentials_prod.sh` isn't needed),
  run the script, then terminate it (a spot instance keeps the one-off cost
  low). See **"Building on a native amd64 machine"** in the doc for the existing-box
  and ephemeral-EC2 recipes.

## GPU/ML + piscis coverage

- The script now builds **and pushes GPU/ML workers** too (cellpose family,
  sam/sam2 family, stardist, condensatenet, deconwolf, deepcell, cellori). They
  build `FROM` public `nvidia/cuda` images, so they need no base redirect and
  push like any other worker.
- **piscis** (non-standard `predict/` + `train/` layout) is handled as two
  pseudo-workers, `piscis_predict` and `piscis_train`, both built with the
  piscis dir as context (matching its `docker-compose.yaml`).
- New flags: `--skip-ml` (exclude `nvidia/cuda` workers incl. piscis) and
  `--only-ml` (build only those, e.g. on a GPU box). `--list` now shows a
  GPU/ML column, and the script **warns** before cross-building any CUDA worker
  under QEMU on a non-amd64 host.
- Net result: a single `./scripts/push_workers_to_ecr.sh --all` on a native
  amd64/GPU EC2 host builds + pushes **everything** (standard + GPU/ML +
  piscis). `build_machine_learning_workers.sh` remains the local-dev build path
  (local image tags, no ECR push).

## Build parallelism

`COMPOSE_PARALLEL_LIMIT` in `build_workers.sh` is now env-overridable (default
`1`, safe on a memory-constrained laptop). Even a beefy EC2 GPU build instance
can't handle many concurrent heavy CUDA/torch builds, so **2–3 is the practical
ceiling**, not higher:

```bash
COMPOSE_PARALLEL_LIMIT=3 ./build_workers.sh
```

## Key implementation details

- Discovers workers from `workers/annotations/` and `workers/properties/`;
  `*_M1` arm64 dev variants are excluded entirely, and test/sample workers are
  skipped by `--all` (still pushable by explicit name).
- Per-worker build context is auto-detected (repo-root vs worker-dir); piscis's
  context is pinned via an override map since it can't be inferred.
- Validates AWS credentials early (`sts get-caller-identity`); appends `-dirty`
  to the SHA tag on a dirty working tree; auto-creates ECR repos on first push
  (with a prompt; `-y` to skip); re-logs-in + retries once on a push auth error;
  keeps a per-worker buildx cache under `.cache/buildx/` (`--no-cache` to
  disable).

## Image naming / tags

```
<acct>.dkr.ecr.<region>.amazonaws.com/<prefix>/<category>/<worker>:<short-git-sha>
<acct>.dkr.ecr.<region>.amazonaws.com/<prefix>/<category>/<worker>:latest
```

Prod registry: account `677276105390`, region `us-east-1`, prefix `nimbus`.

> Verified offline (syntax, `--list`, stubbed-`aws` `--dry-run`). An actual
> GPU/ML build + push should be confirmed on a native amd64/GPU host with live
> credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
