### PR TITLE
Fix stardist worker crash: pin setuptools<82 for pkg_resources

### DIFF
--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -46,7 +46,7 @@ Create new annotations by segmenting images or connecting existing annotations.
 | SAM2 video | Uses SAM2 to track video through time or Z | Yes |  | [docs](workers/annotations/sam2_video/SAM2_VIDEO.md) |
 | SAM automatic mask generator | Uses SAM to find all masks in the image | Yes |  | [docs](workers/annotations/sam_automatic_mask_generator/SAM_AUTOMATIC_MASK_GENERATOR.md) |
 | SAM few-shot segmentation | Uses SAM1 ViT-H features for few-shot segmentation based on training annotations | Yes | Yes | [docs](workers/annotations/sam_fewshot_segmentation/SAM_FEWSHOT_SEGMENTATION.md) |
-| Stardist | Uses Stardist to find cells and nuclei | Yes |  | [docs](workers/annotations/stardist/STARDIST.md) |
+| Stardist | Uses Stardist to find cells and nuclei | Yes | Yes | [docs](workers/annotations/stardist/STARDIST.md) |
 
 ## Property Workers -- Blobs
 

--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -23,8 +23,8 @@ Create new annotations by segmenting images or connecting existing annotations.
 |--------|-------------|-----|-------|------|
 | Claude natural language analyzer | Uses Claude AI to analyze images |  |  | [docs](workers/annotations/ai_analysis/AI_ANALYSIS.md) |
 | Cellori Segmentation |  | Yes |  | [docs](workers/annotations/cellori_segmentation/CELLORI_SEGMENTATION.md) |
-| Cellpose | Uses Cellpose to find cells and nuclei | Yes |  | [docs](workers/annotations/cellpose/CELLPOSE.md) |
-| Cellpose retrain | Retrains Cellpose models based on user-selected images | Yes |  | [docs](workers/annotations/cellpose_train/CELLPOSE_TRAIN.md) |
+| Cellpose | This tool runs the Cellpose model to segment the image into cells. Learn more | Yes |  | [docs](workers/annotations/cellpose/CELLPOSE.md) |
+| Cellpose retrain | This tool trains a Cellpose model using user-corrected annotations. Learn more | Yes |  | [docs](workers/annotations/cellpose_train/CELLPOSE_TRAIN.md) |
 | Cellpose-SAM | This tool runs the Cellpose-SAM model to segment the image into cells. Learn more | Yes |  | [docs](workers/annotations/cellposesam/CELLPOSESAM.md) |
 | CondensateNet segmentation | Segments biomolecular condensates using CondensateNet deep learning model | Yes |  | [docs](workers/annotations/condensatenet/CONDENSATENET.md) |
 | Connect Sequential | This tool connects objects sequentially across time or z-slices.It is useful for connec... |  | Yes | [docs](workers/annotations/connect_sequential/CONNECT_SEQUENTIAL.md) |
@@ -36,13 +36,13 @@ Create new annotations by segmenting images or connecting existing annotations.
 | Gaussian Blur | Applies Gaussian blur to images |  | Yes | [docs](workers/annotations/gaussian_blur/GAUSSIAN_BLUR.md) |
 | H&E Deconvolution | Deconvolves H&E stains |  | Yes | [docs](workers/annotations/h_and_e_deconvolution/H_AND_E_DECONVOLUTION.md) |
 | Histogram Matching | Corrects images using histogram matching |  | Yes | [docs](workers/annotations/histogram_matching/HISTOGRAM_MATCHING.md) |
-| Laplacian of Gaussian | Detects spots in images using the Laplacian of Gaussian method |  |  | [docs](workers/annotations/laplacian_of_gaussian/LAPLACIAN_OF_GAUSSIAN.md) |
+| Laplacian of Gaussian | This tool finds spots in an image using the Laplacian of Gaussian method.It uses a filt... |  |  | [docs](workers/annotations/laplacian_of_gaussian/LAPLACIAN_OF_GAUSSIAN.md) |
 | Time lapse registration | Corrects images using time lapse registration |  | Yes | [docs](workers/annotations/registration/REGISTRATION.md) |
 | Rolling Ball | Corrects images using a rolling ball |  | Yes | [docs](workers/annotations/rolling_ball/ROLLING_BALL.md) |
 | SAM2 automatic mask generator | Uses SAM2 to find all masks in the image | Yes |  | [docs](workers/annotations/sam2_automatic_mask_generator/SAM2_AUTOMATIC_MASK_GENERATOR.md) |
 | SAM2 few-shot segmentation | Uses SAM2 features for few-shot segmentation based on training annotations | Yes | Yes | [docs](workers/annotations/sam2_fewshot_segmentation/SAM2_FEWSHOT_SEGMENTATION.md) |
-| SAM2 propagator | Uses SAM2 to propagate annotations through time or Z-slices | Yes |  | [docs](workers/annotations/sam2_propagate/SAM2_PROPAGATE.md) |
-| SAM2 Refiner | Uses SAM2 to refine annotations | Yes |  | [docs](workers/annotations/sam2_refine/SAM2_REFINE.md) |
+| SAM2 propagator | This tool uses the SAM2 model to take an existing annotation and propagate it through t... | Yes |  | [docs](workers/annotations/sam2_propagate/SAM2_PROPAGATE.md) |
+| SAM2 Refiner | This tool uses the SAM2 model to refine existing annotations. It takes existing annotat... | Yes |  | [docs](workers/annotations/sam2_refine/SAM2_REFINE.md) |
 | SAM2 video | Uses SAM2 to track video through time or Z | Yes |  | [docs](workers/annotations/sam2_video/SAM2_VIDEO.md) |
 | SAM automatic mask generator | Uses SAM to find all masks in the image | Yes |  | [docs](workers/annotations/sam_automatic_mask_generator/SAM_AUTOMATIC_MASK_GENERATOR.md) |
 | SAM few-shot segmentation | Uses SAM1 ViT-H features for few-shot segmentation based on training annotations | Yes | Yes | [docs](workers/annotations/sam_fewshot_segmentation/SAM_FEWSHOT_SEGMENTATION.md) |
@@ -54,16 +54,16 @@ Compute properties on polygon / blob annotations.
 
 | Worker | Description | Tests | Docs |
 |--------|-------------|-------|------|
-| Annulus intensity percentile measurements | Compute intensity at a specific percentile for an annular region around blobs | Yes | [docs](workers/properties/blobs/blob_annulus_intensity_percentile_worker/BLOB_ANNULUS_INTENSITY_PERCENTILE_WORKER.md) |
-| Annulus intensity measurements | Compute intensity measurements (mean, median, etc.) for an annular region around blobs | Yes | [docs](workers/properties/blobs/blob_annulus_intensity_worker/BLOB_ANNULUS_INTENSITY_WORKER.md) |
+| Annulus intensity percentile measurements | This tool computes the pixel intensity in an annulus around the objects in the specifie... | Yes | [docs](workers/properties/blobs/blob_annulus_intensity_percentile_worker/BLOB_ANNULUS_INTENSITY_PERCENTILE_WORKER.md) |
+| Annulus intensity measurements | This tool computes the pixel intensity in an annulus around the objects in the specifie... | Yes | [docs](workers/properties/blobs/blob_annulus_intensity_worker/BLOB_ANNULUS_INTENSITY_WORKER.md) |
 | Colony two color intensity | Compute intensity across two channels for blobs; useful for colony intensity measurements |  | [docs](workers/properties/blobs/blob_colony_two_color_intensity_worker/BLOB_COLONY_TWO_COLOR_INTENSITY_WORKER.md) |
-| Blob intensity percentile measurements | Compute intensity at a specific percentile for blobs | Yes | [docs](workers/properties/blobs/blob_intensity_percentile_worker/BLOB_INTENSITY_PERCENTILE_WORKER.md) |
-| Blob intensity measurements | Compute intensity measurements (mean, median, etc.) for blobs | Yes | [docs](workers/properties/blobs/blob_intensity_worker/BLOB_INTENSITY_WORKER.md) |
-| Blob metrics | Compute area, perimeter, and other metrics for blobs | Yes | [docs](workers/properties/blobs/blob_metrics_worker/BLOB_METRICS_WORKER.md) |
-| Blob overlap | Compute overlap between blobs | Yes | [docs](workers/properties/blobs/blob_overlap_worker/BLOB_OVERLAP_WORKER.md) |
+| Blob intensity percentile measurements | This tool computes the pixel intensity of objects in the specified channel at the speci... | Yes | [docs](workers/properties/blobs/blob_intensity_percentile_worker/BLOB_INTENSITY_PERCENTILE_WORKER.md) |
+| Blob intensity measurements | This tool computes the pixel intensity of objects in the specified channel. It will com... | Yes | [docs](workers/properties/blobs/blob_intensity_worker/BLOB_INTENSITY_WORKER.md) |
+| Blob metrics | This tool computes a variety of metrics for the objects in the specified channel. The m... | Yes | [docs](workers/properties/blobs/blob_metrics_worker/BLOB_METRICS_WORKER.md) |
+| Blob overlap | This tool computes the overlaps between two sets of annotations. The overlap is compute... | Yes | [docs](workers/properties/blobs/blob_overlap_worker/BLOB_OVERLAP_WORKER.md) |
 | Point count 3D projection | Count points in a 3D projection |  | [docs](workers/properties/blobs/blob_point_count_3D_projection_worker/BLOB_POINT_COUNT_3D_PROJECTION_WORKER.md) |
-| Point count | Count the number of points that fall within a blob/polygon; can work in 2D or 3D | Yes | [docs](workers/properties/blobs/blob_point_count_worker/BLOB_POINT_COUNT_WORKER.md) |
-| Random Forest Classifier | Classify blobs using a Random Forest Classifier | Yes | [docs](workers/properties/blobs/blob_random_forest_classifier/BLOB_RANDOM_FOREST_CLASSIFIER.md) |
+| Point count | This tool counts the number of points within polygon annotations. The points will be of... | Yes | [docs](workers/properties/blobs/blob_point_count_worker/BLOB_POINT_COUNT_WORKER.md) |
+| Random Forest Classifier | This tool uses a Random Forest Classifier to classify blobs. | Yes | [docs](workers/properties/blobs/blob_random_forest_classifier/BLOB_RANDOM_FOREST_CLASSIFIER.md) |
 
 ## Property Workers -- Points
 
@@ -72,9 +72,9 @@ Compute properties on point annotations.
 | Worker | Description | Tests | Docs |
 |--------|-------------|-------|------|
 | Point circle intensity | Computes mean intensity metrics around a point; radius 1 for pixel precision |  | [docs](workers/properties/points/point_circle_intensity_mean_worker/POINT_CIRCLE_INTENSITY_MEAN_WORKER.md) |
-| Point intensity | Computes a variety of intensity metrics around a point; radius 1 for pixel precision | Yes | [docs](workers/properties/points/point_circle_intensity_worker/POINT_CIRCLE_INTENSITY_WORKER.md) |
+| Point intensity | This tool computes the average, maximum, minimum, median, total, 25th percentile, and 7... | Yes | [docs](workers/properties/points/point_circle_intensity_worker/POINT_CIRCLE_INTENSITY_WORKER.md) |
 | Point Intensity Worker |  |  | [docs](workers/properties/points/point_intensity_worker/POINT_INTENSITY_WORKER.md) |
-| Point metrics | Computes a variety of metrics for points, like X and Y coordinates | Yes | [docs](workers/properties/points/point_metrics_worker/POINT_METRICS_WORKER.md) |
+| Point metrics | This tool adds a property to the points to document their coordinates. It gives each po... | Yes | [docs](workers/properties/points/point_metrics_worker/POINT_METRICS_WORKER.md) |
 | Point Threshold Intensity Mean Worker |  |  | [docs](workers/properties/points/point_threshold_intensity_mean_worker/POINT_THRESHOLD_INTENSITY_MEAN_WORKER.md) |
 | Distance to nearest blob |  | Yes | [docs](workers/properties/points/point_to_nearest_blob_distance/POINT_TO_NEAREST_BLOB_DISTANCE.md) |
 | Distance from point to nearest other point |  |  | [docs](workers/properties/points/point_to_nearest_connected_point_distance/POINT_TO_NEAREST_CONNECTED_POINT_DISTANCE.md) |
@@ -86,8 +86,8 @@ Compute properties on line annotations.
 
 | Worker | Description | Tests | Docs |
 |--------|-------------|-------|------|
-| length | Compute the length of lines |  | [docs](workers/properties/lines/line_length_worker/LINE_LENGTH_WORKER.md) |
-| Line scan CSV | This tool computes the intensity along a line and puts the results in a CSV file. The i... |  | [docs](workers/properties/lines/line_scan_worker/LINE_SCAN_WORKER.md) |
+| length | Computes the length of lines. |  | [docs](workers/properties/lines/line_length_worker/LINE_LENGTH_WORKER.md) |
+| Line scan CSV | This tool computes the intensity along a line and puts the results in a CSV file. The i... | Yes | [docs](workers/properties/lines/line_scan_worker/LINE_SCAN_WORKER.md) |
 | Test File Creation |  |  | [docs](workers/properties/lines/test_file_creation_worker/TEST_FILE_CREATION_WORKER.md) |
 
 ## Property Workers -- Connections
@@ -96,8 +96,8 @@ Compute properties based on relationships between annotations.
 
 | Worker | Description | Tests | Docs |
 |--------|-------------|-------|------|
-| Count connected objects | Count the number of children objects that are connected to a parent polygon | Yes | [docs](workers/properties/connections/children_count_worker/CHILDREN_COUNT_WORKER.md) |
-| Connection IDs | Creates a set of identifiers that indicate the parent-child relationships between polygons | Yes | [docs](workers/properties/connections/parent_child_worker/PARENT_CHILD_WORKER.md) |
+| Count connected objects | This tool counts the number of children objects that are connected to a parent polygon.... | Yes | [docs](workers/properties/connections/children_count_worker/CHILDREN_COUNT_WORKER.md) |
+| Connection IDs | This tool adds a property to the objects to document the connections between them, whic... | Yes | [docs](workers/properties/connections/parent_child_worker/PARENT_CHILD_WORKER.md) |
 
 ## Test / Sample Workers
 
@@ -108,8 +108,8 @@ Workers used for testing and demonstration -- not intended for production use.
 | Annulus Generator M1 |  |  |  | [docs](workers/annotations/annulus_generator_M1/ANNULUS_GENERATOR_M1.md) |
 | Random point | Creates random point annotations |  |  | [docs](workers/annotations/random_point/RANDOM_POINT.md) |
 | Random Point Annotation M1 |  |  |  | [docs](workers/annotations/random_point_annotation_M1/RANDOM_POINT_ANNOTATION_M1.md) |
-| Random squares | Generates random square polygon annotations for testing |  | Yes | [docs](workers/annotations/random_squares/RANDOM_SQUARES.md) |
-| Sample interface | Demonstrates all interface types, messaging patterns, and batch mode |  | Yes | [docs](workers/annotations/sample_interface/SAMPLE_INTERFACE.md) |
+| Random squares | Generates random square polygon annotations within the image bounds. Useful for testing... |  | Yes | [docs](workers/annotations/random_squares/RANDOM_SQUARES.md) |
+| Sample interface | This is a sample interface worker that demonstrates all available interface types, tool... |  | Yes | [docs](workers/annotations/sample_interface/SAMPLE_INTERFACE.md) |
 | Test Multiple Annotation |  |  |  | [docs](workers/annotations/test_multiple_annotation/TEST_MULTIPLE_ANNOTATION.md) |
 | Test Multiple Annotation M1 |  |  |  | [docs](workers/annotations/test_multiple_annotation_M1/TEST_MULTIPLE_ANNOTATION_M1.md) |
 

--- a/workers/annotations/stardist/download_models.py
+++ b/workers/annotations/stardist/download_models.py
@@ -17,10 +17,15 @@ def download_models():
         print("Traceback:")
         traceback.print_exc()
         print("\nPlease check your environment and package versions.")
+        # Fail the Docker build instead of shipping an image that crashes at
+        # runtime on `import stardist`.
+        sys.exit(1)
     except Exception as e:
         print(f"An unexpected error occurred: {e}")
         print("Traceback:")
         traceback.print_exc()
+        # Fail the Docker build if the models can't be downloaded/cached.
+        sys.exit(1)
 
 if __name__ == "__main__":
     download_models()

--- a/workers/annotations/stardist/environment.yml
+++ b/workers/annotations/stardist/environment.yml
@@ -5,6 +5,9 @@ channels:
 dependencies:
   - python=3.10
   - pip
+  # stardist 0.9.1 imports pkg_resources at import time, which setuptools
+  # removed in 82.0.0. Pin below that so pkg_resources stays available.
+  - setuptools<82
   - numpy=1.23.5
   - scipy=1.10.1
   - scikit-image=0.19.3

--- a/workers/annotations/stardist/tests/test_download_models.py
+++ b/workers/annotations/stardist/tests/test_download_models.py
@@ -1,0 +1,51 @@
+"""Tests for the build-time model download script.
+
+The Dockerfile runs ``download_models.py`` during the image build. If a
+dependency is broken (e.g. ``stardist`` can't be imported because setuptools
+removed ``pkg_resources``), the script MUST exit non-zero so the Docker build
+fails loudly instead of shipping a broken image that only crashes at runtime.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "download_models.py"
+
+
+def _run_with_broken_stardist(tmp_path):
+    """Run download_models.py with a `stardist` package that fails to import.
+
+    A fake ``stardist`` package is placed first on PYTHONPATH so it shadows any
+    real install, making the import failure deterministic regardless of the
+    environment the test runs in.
+    """
+    pkg = tmp_path / "stardist"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text(
+        "raise ImportError(\"No module named 'pkg_resources'\")\n"
+    )
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(tmp_path) + os.pathsep + env.get("PYTHONPATH", "")
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_exits_nonzero_when_stardist_import_fails(tmp_path):
+    result = _run_with_broken_stardist(tmp_path)
+    assert result.returncode != 0, (
+        "download_models.py swallowed the import failure and exited 0; "
+        "the Docker build would succeed and ship a broken image"
+    )
+
+
+def test_reports_the_import_error(tmp_path):
+    result = _run_with_broken_stardist(tmp_path)
+    combined = result.stdout + result.stderr
+    assert "Error importing StarDist" in combined
+    assert "pkg_resources" in combined


### PR DESCRIPTION
## Problem

The stardist worker crashed at runtime in the deployment build with:

```
File "/root/miniforge3/envs/worker/lib/python3.10/site-packages/stardist/bioimageio_utils.py", line 2, in <module>
    from pkg_resources import get_distribution
ModuleNotFoundError: No module named 'pkg_resources'
```

## Root cause

`stardist==0.9.1` imports `from pkg_resources import get_distribution` at **import time** — `stardist/__init__.py` pulls in `bioimageio_utils.py`, which fails immediately. `pkg_resources` was bundled with `setuptools`, but **setuptools 82.0.0 (released Feb 2026) removed it entirely**.

`workers/annotations/stardist/environment.yml` did not pin `setuptools`, so fresh builds resolved setuptools ≥82 and shipped an image without `pkg_resources`. The image used to build/run fine only because earlier builds happened to get setuptools <82. This is unpinned-transitive-dependency drift.

## Why the build didn't catch it

`download_models.py` runs at build time and does `from stardist.models import StarDist2D`, so the build *touched* the broken import — but it wrapped the import in `except ImportError` / `except Exception` that only **printed** the traceback and then exited 0. Docker saw a successful `RUN`, so the image built and pushed "successfully" (with the models never cached), and the failure only surfaced at runtime.

## Fixes

1. **Pin `setuptools<82`** in the conda dependencies so `pkg_resources` stays available. This is the layer where setuptools is installed; none of the later pip steps require setuptools ≥82, so the pin holds through the build.
2. **Make `download_models.py` exit non-zero** on import/download failure, so future dependency drift fails the Docker build loudly instead of shipping a broken image.

## Tests

Added `workers/annotations/stardist/tests/test_download_models.py` (stdlib-only, runs under plain pytest). It runs the script with a fake `stardist` package shadowing any real install so the import fails deterministically, and asserts the script exits non-zero and reports the error. Written test-first (failed against the old swallow-and-exit-0 behavior, passes after the fix).

```
$ pytest workers/annotations/stardist/tests -q
2 passed
```

## Verification

The `setuptools<82` pin itself can't be validated by a local rebuild here (GPU/CUDA worker, not buildable on a Mac dev machine). After the next deployment build, confirm the worker imports cleanly:

```bash
docker run --rm --entrypoint conda <image> run -n worker \
  python -c "import pkg_resources, stardist; print('ok', stardist.__version__)"
```

Sources for the setuptools 82.0.0 `pkg_resources` removal:
- https://github.com/pypa/setuptools/issues/5174
- https://github.com/tensorflow/hub/issues/934

🤖 Generated with [Claude Code](https://claude.com/claude-code)