### PR TITLE
chore: disable worker-docs PR hooks

### DIFF
--- a/.claude/hooks/update-worker-docs.sh
+++ b/.claude/hooks/update-worker-docs.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# DISABLED: no longer registered in .claude/settings.json. Kept for reference.
+# Removed because it auto-committed a full REGISTRY.md regeneration on every
+# `gh pr create`/`edit`, sweeping unrelated worker-description drift into
+# focused PRs. Run `python generate_worker_docs.py` manually instead.
+#
 # Claude Code PostToolUse hook — regenerates worker docs when a PR is created.
 #
 # Triggers after any Bash tool call. Checks whether the command was a

--- a/.claude/hooks/validate-worker-docs.sh
+++ b/.claude/hooks/validate-worker-docs.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+# DISABLED: no longer registered in .claude/settings.json. Kept for reference.
+# Removed because requiring a REGISTRY.md update on every worker change blocked
+# logic-only PRs and forced noisy registry regeneration into the diff. Run
+# `python generate_worker_docs.py` manually when docs actually need updating.
+#
 # Pre-PR hook: validates that modified workers have documentation and REGISTRY.md is updated.
 # Called as a PreToolUse hook on Bash commands. Reads tool input JSON from stdin.
 # Exit 0 = allow, Exit 2 = block with message.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,26 +1,3 @@
 {
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/validate-worker-docs.sh\""
-          }
-        ]
-      }
-    ],
-    "PostToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/update-worker-docs.sh"
-          }
-        ]
-      }
-    ]
-  }
+  "hooks": {}
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,14 +28,21 @@ python generate_worker_docs.py --registry-only
 
 The script reads each `entrypoint.py` via AST parsing to extract the interface definition and Docker labels, then writes the markdown files. **By default, it only creates stubs for workers that don't already have a doc file** — existing hand-written documentation is preserved. Use `--force` to overwrite. Workers with dynamically-computed interface values (e.g. model lists fetched from Girder) are handled gracefully — static fields are extracted and dynamic ones are flagged.
 
-### Automatic Documentation via Claude Code Hook
+### Automatic Documentation via Claude Code Hook (DISABLED)
 
-A `PostToolUse` Claude Code hook (`.claude/hooks/update-worker-docs.sh`) fires automatically after any `gh pr create` or `gh pr edit` Bash command. It:
-1. Runs `generate_worker_docs.py` to regenerate all worker docs and `registry.md`
-2. Commits any changes
-3. Pushes the commit to the current branch so the PR always contains up-to-date docs
+> **Disabled.** This hook is no longer registered in `.claude/settings.json`.
+> The script (`.claude/hooks/update-worker-docs.sh`) is kept for reference and
+> can be re-registered if desired. It was disabled because it auto-regenerated
+> `REGISTRY.md` on every `gh pr create`/`edit` and committed the result, which
+> repeatedly swept **unrelated description drift** (stale one-line summaries for
+> workers untouched by the PR) into otherwise-focused PRs. Regenerate docs
+> manually with `python generate_worker_docs.py` when a worker's interface or
+> labels actually change.
 
-The hook is registered in `.claude/settings.json`.
+When it was active, the `PostToolUse` hook (`.claude/hooks/update-worker-docs.sh`) fired automatically after any `gh pr create` or `gh pr edit` Bash command and:
+1. Ran `generate_worker_docs.py` to regenerate all worker docs and `registry.md`
+2. Committed any changes
+3. Pushed the commit to the current branch so the PR always contained up-to-date docs
 
 ### Documentation Conventions
 
@@ -490,9 +497,16 @@ Use existing docs as reference:
 - **Comprehensive template**: `workers/annotations/deconwolf/DECONWOLF.md`
 - **Concise template**: `workers/annotations/condensatenet/CONDENSATENET.md`
 
-### Pre-PR Validation Hook
+### Pre-PR Validation Hook (DISABLED)
 
-A Claude Code hook (`.claude/hooks/validate-worker-docs.sh`) runs before `gh pr create` and checks:
+> **Disabled.** This hook is no longer registered in `.claude/settings.json`.
+> The script (`.claude/hooks/validate-worker-docs.sh`) is kept for reference and
+> can be re-registered if desired. It was disabled alongside the auto-doc hook
+> above: its `REGISTRY.md`-was-updated check blocked PRs that only changed worker
+> *logic* (no interface change), forcing a noisy registry regeneration into the
+> PR just to pass. Keeping worker docs current is now a manual step.
+
+When it was active, the `PreToolUse` hook (`.claude/hooks/validate-worker-docs.sh`) ran before `gh pr create` and checked:
 - Every modified annotation worker has a `WORKERNAME.md` doc file
 - Every modified property worker has a `WORKERNAME.md` doc file (not just a boilerplate README.md)
 - `REGISTRY.md` was updated if any worker files changed


### PR DESCRIPTION
## Why

The two worker-docs Claude Code hooks repeatedly caused friction on PRs:

- **`update-worker-docs.sh`** (PostToolUse) re-ran `generate_worker_docs.py` and committed the result on every `gh pr create`/`edit`. Because the committed `REGISTRY.md` drifts from the generator's current output, this swept **unrelated one-line description changes** (for workers the PR never touched) into otherwise-focused diffs.
- **`validate-worker-docs.sh`** (PreToolUse) blocked any PR that modified a worker without also updating `REGISTRY.md` — forcing that same noisy regeneration into logic-only PRs just to pass the check.

(Concretely: the polygon-geometry fix in #145 is a pure logic change, yet these hooks wanted ~21 lines of unrelated `REGISTRY.md` description churn committed alongside it.)

## What

- Unregister both hooks from `.claude/settings.json` (now `{ "hooks": {} }`).
- **Keep** both scripts in `.claude/hooks/` with a `DISABLED` note at the top of each, so they can be re-registered later.
- Update `CLAUDE.md` to mark both hook sections **DISABLED** and explain why.

Worker docs / `REGISTRY.md` become a manual step: run `python generate_worker_docs.py` when a worker's interface or labels actually change.

## Not changed

`generate_worker_docs.py` itself is untouched — only the automatic invocation/validation is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgYphJWw3jgQoLx5MXz95h
