### PR TITLE
Ignore generated Python and local build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Python bytecode and test caches
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# Python packaging artifacts
+*.egg-info/
+build/
+dist/
+
+# Local virtual environments
+.venv/
+venv/
+
+# Local build and tooling caches
+.cache/


### PR DESCRIPTION
## Summary

- add a root `.gitignore` for Python bytecode, test/tool caches, packaging artifacts, local virtual environments, and local build caches
- keep generated `__pycache__`, `*.egg-info`, and `.cache` content out of Git status

## Why

Local validation and editable installs produced thousands of untracked generated files, obscuring meaningful repository changes.

## Validation

- `git diff --check origin/master...HEAD`
- verified representative `.cache`, `__pycache__`, and `*.egg-info` paths with `git check-ignore -v`