### PR TITLE
chore: expand .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,27 @@
-# Python bytecode and test caches
+# Python bytecode
 __pycache__/
 *.py[cod]
+*$py.class
+
+# Packaging / build artifacts
+*.egg-info/
+*.egg
+build/
+dist/
+.eggs/
+
+# Test / tooling caches
 .pytest_cache/
 .mypy_cache/
 .ruff_cache/
 
-# Python packaging artifacts
-*.egg-info/
-build/
-dist/
-
-# Local virtual environments
+# Virtual environments
 .venv/
 venv/
+env/
 
-# Local build and tooling caches
+# Docker buildx cache (produced by build_workers.sh)
 .cache/
+
+# macOS
+.DS_Store


### PR DESCRIPTION
## Summary
Reorganizes and extends the repo's `.gitignore` with a few commonly-needed ignores that were missing.

### Added
- `*$py.class` (Python bytecode)
- `*.egg`, `.eggs/` (packaging artifacts)
- `env/` (virtual environments)
- `.DS_Store` (macOS)

### Also
- Clearer section headers
- Explanatory comment noting `.cache/` is the Docker buildx cache produced by `build_workers.sh`

No functional/code changes — ignore rules only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)