### PR TITLE
chore: add isGPUWorker label to cellposesam_train

### DIFF
--- a/workers/annotations/cellposesam_train/Dockerfile
+++ b/workers/annotations/cellposesam_train/Dockerfile
@@ -60,6 +60,7 @@ COPY ./worker_client /worker_client
 RUN pip install /worker_client
 
 LABEL isUPennContrastWorker="" \
+      isGPUWorker="true" \
       isAnnotationWorker="" \
       interfaceName="Cellpose-SAM retrain" \
       interfaceCategory="Cellpose" \


### PR DESCRIPTION
## Summary
Adds the missing `isGPUWorker="true"` Docker label to the **Cellpose-SAM retrain** worker (`cellposesam_train`).

The worker is already GPU-accelerated — it uses a CUDA base image, declares `com.nvidia.volumes.needed`, and calls `cellpose.core.use_gpu()` at runtime — but its `LABEL` block was missing the `isGPUWorker` flag that the platform uses to identify GPU workers. This brings it in line with the main `cellposesam` worker and `cellpose_train`.

### Change
```diff
 LABEL isUPennContrastWorker="" \
+      isGPUWorker="true" \
       isAnnotationWorker="" \
```

No code or runtime-behavior changes — Docker metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)