### PR TITLE
fix: guard polygon construction in segmentation workers

### DIFF
--- a/.agents/skills/nimbus-worker-hardening/SKILL.md
+++ b/.agents/skills/nimbus-worker-hardening/SKILL.md
@@ -125,11 +125,49 @@ for coords in geometry_to_polygon_coords(geometry):   # returns [] if degenerate
     # build one polygon annotation from coords
 ```
 
+**But the geometry has to exist first.** `geometry_to_polygon_coords` only
+guards the code *after* construction, and construction is the other half of this
+failure mode:
+
+* `Polygon(contour)` raises `ValueError: A linearring requires at least 4
+  coordinates` for a 1-2 point contour (a one-pixel-wide mask);
+* a contour carrying a NaN/inf coordinate builds fine, then detonates inside
+  `.simplify()` with `GEOSException: Non-finite envelope bounds` -- which is not
+  a `ValueError`, so it slips past a naive `except ValueError`.
+
+Both abort the whole run, so one unusable mask out of hundreds loses every good
+annotation in the frame. Never call `Polygon()`/`.buffer()`/`.simplify()` bare on
+model output; use the guarded helpers, which return `None`/`[]` instead of
+raising:
+```python
+from annotation_utilities.annotation_tools import (
+    clean_polygon_coords, safe_polygon, safe_buffer, safe_simplify)
+
+# contour -> annotation-ready rings in one step (buffer, then simplify)
+for coords in clean_polygon_coords(contour, padding=padding, smoothing=smoothing):
+    ...                                     # [] if anything was unusable
+
+# or, where the worker needs the geometry itself (SAM family)
+polygon = safe_simplify(safe_polygon(contour), smoothing)
+if polygon is not None:
+    polygons.append(polygon)
+```
+`safe_polygon` also rejects non-finite coordinates up front and drops a third
+coordinate column (a 3D ring yields 3-tuples, which break the `(x, y)` unpacking
+used to build annotation coordinates).
+
 **Sweep:**
 ```bash
 grep -rn "\.exterior\.coords" workers/ annotation_utilities/   # candidates to route through the helper
 grep -rn "\.buffer(\|\.simplify(" workers/                     # sources of degenerate geometry
+grep -rn "Polygon(" workers/ | grep -v safe_polygon              # unguarded construction
 ```
+Covered so far: cellposesam/cellpose/condensatenet (`clean_polygon_coords`),
+sam2_video/sam2_propagate/sam2_refine and the SAM/SAM2 automatic-mask-generator
+and few-shot workers (`safe_*`), plus the `worker_client` and
+`polygons_to_annotations` upload chokepoints. Still unguarded: the
+`cellpose_train`/`cellposesam_train` region-polygon reads, where a degenerate
+*user* annotation can still abort a training run.
 
 ### 4. Out-of-range batch coordinates
 

--- a/.claude/skills/nimbus-worker-hardening/SKILL.md
+++ b/.claude/skills/nimbus-worker-hardening/SKILL.md
@@ -125,11 +125,49 @@ for coords in geometry_to_polygon_coords(geometry):   # returns [] if degenerate
     # build one polygon annotation from coords
 ```
 
+**But the geometry has to exist first.** `geometry_to_polygon_coords` only
+guards the code *after* construction, and construction is the other half of this
+failure mode:
+
+* `Polygon(contour)` raises `ValueError: A linearring requires at least 4
+  coordinates` for a 1-2 point contour (a one-pixel-wide mask);
+* a contour carrying a NaN/inf coordinate builds fine, then detonates inside
+  `.simplify()` with `GEOSException: Non-finite envelope bounds` -- which is not
+  a `ValueError`, so it slips past a naive `except ValueError`.
+
+Both abort the whole run, so one unusable mask out of hundreds loses every good
+annotation in the frame. Never call `Polygon()`/`.buffer()`/`.simplify()` bare on
+model output; use the guarded helpers, which return `None`/`[]` instead of
+raising:
+```python
+from annotation_utilities.annotation_tools import (
+    clean_polygon_coords, safe_polygon, safe_buffer, safe_simplify)
+
+# contour -> annotation-ready rings in one step (buffer, then simplify)
+for coords in clean_polygon_coords(contour, padding=padding, smoothing=smoothing):
+    ...                                     # [] if anything was unusable
+
+# or, where the worker needs the geometry itself (SAM family)
+polygon = safe_simplify(safe_polygon(contour), smoothing)
+if polygon is not None:
+    polygons.append(polygon)
+```
+`safe_polygon` also rejects non-finite coordinates up front and drops a third
+coordinate column (a 3D ring yields 3-tuples, which break the `(x, y)` unpacking
+used to build annotation coordinates).
+
 **Sweep:**
 ```bash
 grep -rn "\.exterior\.coords" workers/ annotation_utilities/   # candidates to route through the helper
 grep -rn "\.buffer(\|\.simplify(" workers/                     # sources of degenerate geometry
+grep -rn "Polygon(" workers/ | grep -v safe_polygon              # unguarded construction
 ```
+Covered so far: cellposesam/cellpose/condensatenet (`clean_polygon_coords`),
+sam2_video/sam2_propagate/sam2_refine and the SAM/SAM2 automatic-mask-generator
+and few-shot workers (`safe_*`), plus the `worker_client` and
+`polygons_to_annotations` upload chokepoints. Still unguarded: the
+`cellpose_train`/`cellposesam_train` region-polygon reads, where a degenerate
+*user* annotation can still abort a training run.
 
 ### 4. Out-of-range batch coordinates
 

--- a/annotation_utilities/annotation_utilities/annotation_tools.py
+++ b/annotation_utilities/annotation_utilities/annotation_tools.py
@@ -1,6 +1,16 @@
 from shapely.geometry import Point, Polygon
 import numpy as np
 
+try:  # shapely >= 2.0
+    from shapely.errors import GEOSException as _GEOSException
+except ImportError:  # pragma: no cover - shapely 1.x fallback
+    from shapely.errors import ShapelyError as _GEOSException
+
+# Everything shapely throws when handed a geometry it cannot work with. GEOS
+# errors are not ValueErrors, so they slip past a naive `except ValueError` and
+# kill the worker run.
+GEOMETRY_ERRORS = (ValueError, TypeError, AttributeError, _GEOSException)
+
 
 # Note that this function should reverse x and y. It is used by point_count_worker, which mixes up x and y for the polygons as well, so it works consistently.
 # But that's not good. This function should not be used outside of the point_count_worker.
@@ -189,10 +199,105 @@ def geometry_to_polygon_coords(geometry, keep_largest_only=False):
             coords = [max(coords, key=lambda ring: Polygon(ring).area)]
         return coords
     exterior = getattr(geometry, "exterior", None)
-    if exterior is None or not geometry.is_valid or geometry.area <= 0:
-        # not a polygon, invalid (self-intersecting), or a degenerate sliver
+    if exterior is None:
+        return []  # not a polygon (a Point/LineString has no exterior)
+    try:
+        # `not (area > 0)` rather than `area <= 0` so a NaN area (from non-finite
+        # coordinates) is rejected too -- every NaN comparison is False.
+        if not geometry.is_valid or not (geometry.area > 0):
+            # invalid (self-intersecting) or a degenerate sliver
+            return []
+    except GEOMETRY_ERRORS:
         return []
     return [list(exterior.coords)]
+
+
+def safe_polygon(coords):
+    """Build a shapely ``Polygon`` from raw coordinates, or return ``None``.
+
+    ``geometry_to_polygon_coords`` only protects the code *after* a geometry
+    exists; this protects the construction itself, which is where segmentation
+    workers actually crash. ``Polygon(coords)`` raises ``ValueError`` for a
+    contour with fewer than 3 points (a one-pixel-wide mask), and a contour
+    carrying a NaN/inf coordinate builds a geometry that detonates later inside
+    ``simplify()`` with a ``GEOSException``. Both abort the entire worker run, so
+    one unusable mask out of hundreds loses every good annotation in the frame.
+
+    ``coords`` may be a coordinate sequence (list of ``(x, y)`` tuples, a numpy
+    contour array, ...) or an already-built geometry, which is returned as-is. A
+    third coordinate column is dropped: a 3D ring yields 3-tuples, which break
+    the ``(x, y)`` unpacking used to build annotation coordinates.
+
+    Returns a ``Polygon``, or ``None`` if the input cannot form a usable one.
+    """
+    if coords is None:
+        return None
+    if hasattr(coords, "geom_type"):  # already a shapely geometry
+        return coords
+    try:
+        array = np.asarray(coords, dtype=float)
+    except (TypeError, ValueError):
+        return None  # e.g. a list of dicts, or a string
+    if array.ndim != 2 or array.shape[0] < 3 or array.shape[1] < 2:
+        return None  # too few points, or not (x, y) pairs, to form a ring
+    array = array[:, :2]
+    if not np.isfinite(array).all():
+        return None
+    try:
+        return Polygon(array)
+    except GEOMETRY_ERRORS:
+        return None
+
+
+def safe_buffer(geometry, distance):
+    """``geometry.buffer(distance)``, tolerating ``None`` and GEOS failures.
+
+    Used for polygon padding. Returns ``None`` if there is nothing to buffer or
+    the operation fails; an empty result is left to
+    ``geometry_to_polygon_coords`` to drop.
+    """
+    if geometry is None:
+        return None
+    try:
+        return geometry.buffer(distance)
+    except GEOMETRY_ERRORS:
+        return None
+
+
+def safe_simplify(geometry, tolerance, preserve_topology=True):
+    """``geometry.simplify(tolerance)``, tolerating ``None`` and GEOS failures.
+
+    Used for polygon smoothing. A geometry built from non-finite coordinates
+    raises ``GEOSException: Non-finite envelope bounds`` here, which is fatal to
+    the run unless caught.
+    """
+    if geometry is None:
+        return None
+    try:
+        return geometry.simplify(tolerance, preserve_topology=preserve_topology)
+    except GEOMETRY_ERRORS:
+        return None
+
+
+def clean_polygon_coords(coords, padding=0, smoothing=0, keep_largest_only=False):
+    """Turn one raw mask contour into annotation-ready coordinate rings.
+
+    This is the whole guarded pipeline the segmentation workers need: build the
+    polygon, apply optional ``padding`` (buffer) then ``smoothing`` (simplify) --
+    the order the cellpose-family workers have always used -- and normalize the
+    result with :func:`geometry_to_polygon_coords`. Anything unusable at any step
+    is dropped rather than raised, so a single bad contour costs one object
+    instead of the entire frame.
+
+    Returns a (possibly empty) list of coordinate lists, each a list of
+    ``(x, y)`` tuples ready to become one polygon annotation.
+    """
+    geometry = safe_polygon(coords)
+    if padding:
+        geometry = safe_buffer(geometry, padding)
+    if smoothing and smoothing > 0:
+        geometry = safe_simplify(geometry, smoothing)
+    return geometry_to_polygon_coords(geometry, keep_largest_only=keep_largest_only)
 
 
 def polygons_to_annotations(polygons, datasetId, XY=0, Time=0, Z=0, tags=None, channel=0):

--- a/annotation_utilities/tests/test_polygon_cleaning.py
+++ b/annotation_utilities/tests/test_polygon_cleaning.py
@@ -1,14 +1,19 @@
 import sys
 from pathlib import Path
 
+import numpy as np
 from shapely.geometry import Polygon
 
 package_root = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(package_root))
 
 from annotation_utilities.annotation_tools import (
+    clean_polygon_coords,
     geometry_to_polygon_coords,
     polygons_to_annotations,
+    safe_buffer,
+    safe_polygon,
+    safe_simplify,
 )
 
 
@@ -143,3 +148,128 @@ def test_polygons_to_annotations_preserves_xy_swap_and_drops_closing_point():
     assert annotations[0]["location"] == {"XY": 4, "Time": 5, "Z": 6}
     assert annotations[0]["tags"] == ["t"]
     assert annotations[0]["channel"] == 2
+
+
+# ---------------------------------------------------------------------------
+# safe_polygon / safe_buffer / safe_simplify: guarding geometry *construction*
+#
+# The geometry_to_polygon_coords chokepoint above only helps once a shapely
+# geometry exists. Segmentation workers build that geometry from raw mask
+# contours, where construction itself can blow up and take the whole run with
+# it: a 1-2 point contour raises ValueError, and a non-finite coordinate makes
+# simplify() raise GEOSException.
+# ---------------------------------------------------------------------------
+
+def test_safe_polygon_builds_a_valid_ring():
+    poly = safe_polygon([(0, 0), (10, 0), (10, 10), (0, 10)])
+    assert poly is not None
+    assert poly.area == 100
+
+
+def test_safe_polygon_rejects_contours_too_short_to_form_a_ring():
+    # Polygon() raises ValueError: A linearring requires at least 4 coordinates.
+    assert safe_polygon([(0, 0), (1, 1)]) is None
+    assert safe_polygon([(0, 0)]) is None
+    assert safe_polygon([]) is None
+
+
+def test_safe_polygon_rejects_non_finite_coordinates():
+    # These construct fine but explode later, inside simplify().
+    assert safe_polygon([(0, 0), (np.nan, 5), (10, 10), (0, 10)]) is None
+    assert safe_polygon([(0, 0), (np.inf, 5), (10, 10), (0, 10)]) is None
+
+
+def test_safe_polygon_rejects_non_coordinate_input():
+    assert safe_polygon(None) is None
+    assert safe_polygon("not coordinates") is None
+    assert safe_polygon([{"x": 1, "y": 2}]) is None
+
+
+def test_safe_polygon_accepts_numpy_contours():
+    contour = np.array([[0.0, 0.0], [8.0, 0.0], [8.0, 8.0], [0.0, 8.0]])
+    poly = safe_polygon(contour)
+    assert poly is not None
+    assert poly.area == 64
+
+
+def test_safe_polygon_ignores_a_third_coordinate_column():
+    # A 3D ring would yield 3-tuples, which crash the (x, y) unpacking used to
+    # build annotation coordinates.
+    poly = safe_polygon([(0, 0, 5), (10, 0, 5), (10, 10, 5), (0, 10, 5)])
+    assert poly is not None
+    assert all(len(point) == 2 for point in poly.exterior.coords)
+
+
+def test_safe_polygon_passes_through_an_existing_geometry():
+    square = Polygon([(0, 0), (4, 0), (4, 4), (0, 4)])
+    assert safe_polygon(square) is square
+
+
+def test_safe_buffer_and_simplify_tolerate_none():
+    assert safe_buffer(None, -1) is None
+    assert safe_simplify(None, 0.7) is None
+
+
+def test_safe_simplify_survives_geos_failure_on_non_finite_geometry():
+    # Bypasses safe_polygon to prove the transform guard stands on its own:
+    # this raises GEOSException (Non-finite envelope bounds) unguarded.
+    nan_poly = Polygon([(0, 0), (np.nan, 5), (10, 10), (0, 10)])
+    assert safe_simplify(nan_poly, 0.7) is None
+
+
+def test_safe_buffer_returns_empty_geometry_rather_than_raising():
+    tiny = Polygon([(0, 0), (1.5, 0), (1.5, 1.5), (0, 1.5)])
+    eroded = safe_buffer(tiny, -1.0)
+    # Empty is fine here -- geometry_to_polygon_coords drops it downstream.
+    assert eroded is None or eroded.is_empty
+
+
+# ---------------------------------------------------------------------------
+# clean_polygon_coords: contour -> annotation-ready rings, in one guarded step
+# ---------------------------------------------------------------------------
+
+def test_clean_polygon_coords_applies_padding_and_smoothing():
+    square = [(0, 0), (20, 0), (20, 20), (0, 20)]
+    rings = clean_polygon_coords(square, padding=-1.0, smoothing=0.7)
+    assert len(rings) == 1
+    assert Polygon(rings[0]).area < 400  # eroded by the negative padding
+
+
+def test_clean_polygon_coords_drops_unconstructable_contour():
+    assert clean_polygon_coords([(0, 0), (1, 1)], padding=-1.0, smoothing=0.7) == []
+
+
+def test_clean_polygon_coords_drops_non_finite_contour():
+    nan_contour = [(0, 0), (np.nan, 5), (10, 10), (0, 10)]
+    assert clean_polygon_coords(nan_contour, padding=-1.0, smoothing=0.7) == []
+
+
+def test_clean_polygon_coords_drops_contour_eroded_away():
+    tiny = [(0, 0), (1.5, 0), (1.5, 1.5), (0, 1.5)]
+    assert clean_polygon_coords(tiny, padding=-1.0) == []
+
+
+def test_clean_polygon_coords_expands_multipolygon_into_separate_rings():
+    dumbbell = [
+        (0, 0), (10, 0), (10, 4), (6, 4), (6, 5), (10, 5), (10, 9),
+        (0, 9), (0, 5), (4, 5), (4, 4), (0, 4),
+    ]
+    rings = clean_polygon_coords(dumbbell, padding=-1.0)
+    assert len(rings) == 2
+    assert all(len(ring) >= 4 for ring in rings)
+
+
+def test_clean_polygon_coords_can_collapse_to_the_largest_piece():
+    dumbbell = [
+        (0, 0), (10, 0), (10, 4), (6, 4), (6, 5), (10, 5), (10, 9),
+        (0, 9), (0, 5), (4, 5), (4, 4), (0, 4),
+    ]
+    rings = clean_polygon_coords(dumbbell, padding=-1.0, keep_largest_only=True)
+    assert len(rings) == 1
+
+
+def test_clean_polygon_coords_without_transforms_returns_the_ring():
+    square = [(0, 0), (10, 0), (10, 10), (0, 10)]
+    rings = clean_polygon_coords(square)
+    assert len(rings) == 1
+    assert Polygon(rings[0]).area == 100

--- a/worker_client/tests/test_polygon_cleaning.py
+++ b/worker_client/tests/test_polygon_cleaning.py
@@ -165,3 +165,49 @@ def test_create_polygon_annotations_skips_invalid_polygon(monkeypatch):
 
     assert len(recorder.created) == 1
     assert len(recorder.created[0]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Guarded geometry construction, re-exported for the segmentation workers
+# ---------------------------------------------------------------------------
+
+def test_construction_helpers_are_reexported(monkeypatch):
+    """Workers import these from worker_client, not annotation_utilities."""
+    wc = _load_worker_client_module(monkeypatch)
+    assert wc.safe_polygon([(0, 0), (10, 0), (10, 10), (0, 10)]) is not None
+    assert wc.safe_polygon([(0, 0), (1, 1)]) is None
+    assert wc.clean_polygon_coords([(0, 0), (1, 1)], padding=-1, smoothing=0.7) == []
+    assert len(wc.clean_polygon_coords([(0, 0), (20, 0), (20, 20), (0, 20)],
+                                       padding=-1, smoothing=0.7)) == 1
+
+
+def test_create_polygon_annotations_skips_non_finite_polygon(monkeypatch):
+    """A NaN coordinate must not reach the server (nor crash on the way)."""
+    recorder = RecordingAnnotationClient()
+    wc = _load_worker_client_module(monkeypatch, recorder)
+    worker = wc.WorkerClient("ds", "http://api", "tok", _params())
+
+    valid = [(0, 0), (10, 0), (10, 10), (0, 10)]
+    nan_polygon = [(0, 0), (float("nan"), 5), (10, 10), (0, 10)]
+
+    worker.create_polygon_annotations((0, 0, 0, 0), [valid, nan_polygon])
+
+    assert len(recorder.created) == 1
+    assert len(recorder.created[0]) == 1
+    for point in recorder.created[0][0]["coordinates"]:
+        assert point["x"] == point["x"]  # not NaN
+
+
+def test_create_polygon_annotations_handles_three_column_coords(monkeypatch):
+    """A ring carrying a z column must not break (x, y) unpacking."""
+    recorder = RecordingAnnotationClient()
+    wc = _load_worker_client_module(monkeypatch, recorder)
+    worker = wc.WorkerClient("ds", "http://api", "tok", _params())
+
+    worker.create_polygon_annotations(
+        (0, 0, 0, 0), [[(0, 0, 3), (10, 0, 3), (10, 10, 3), (0, 10, 3)]])
+
+    assert len(recorder.created) == 1
+    uploaded = recorder.created[0][0]["coordinates"]
+    assert len(uploaded) >= 4
+    assert all(set(point) == {"x", "y", "z"} for point in uploaded)

--- a/worker_client/worker_client/__init__.py
+++ b/worker_client/worker_client/__init__.py
@@ -1,1 +1,3 @@
-from .worker_client import WorkerClient, geometry_to_polygon_coords
+from .worker_client import (WorkerClient, clean_polygon_coords,
+                            geometry_to_polygon_coords, safe_buffer,
+                            safe_polygon, safe_simplify)

--- a/worker_client/worker_client/worker_client.py
+++ b/worker_client/worker_client/worker_client.py
@@ -3,7 +3,6 @@ import numpy as np
 from itertools import product
 from math import prod
 from operator import itemgetter
-from shapely.geometry import Polygon
 from typing import Sequence
 
 import annotation_client.annotations as annotations
@@ -11,8 +10,10 @@ import annotation_client.tiles as tiles
 
 from annotation_client.utils import sendProgress
 from annotation_utilities import batch_argument_parser
-# Re-exported for workers that import it from worker_client (e.g. cellposesam).
-from annotation_utilities.annotation_tools import geometry_to_polygon_coords
+# Re-exported for workers that import them from worker_client (e.g. cellposesam).
+from annotation_utilities.annotation_tools import (
+    clean_polygon_coords, geometry_to_polygon_coords, safe_buffer, safe_polygon,
+    safe_simplify)
 
 
 class WorkerClient:
@@ -219,10 +220,10 @@ class WorkerClient:
         skipped = 0
 
         for polygon in polygons:
-            try:
-                geom = Polygon(polygon)
-            except (ValueError, TypeError):
-                # Fewer than the 3 distinct vertices a polygon requires.
+            # safe_polygon returns None for anything that cannot form a ring
+            # (fewer than 3 vertices, non-finite coordinates, ...).
+            geom = safe_polygon(polygon)
+            if geom is None:
                 skipped += 1
                 continue
             coord_lists = geometry_to_polygon_coords(geom)

--- a/workers/annotations/cellpose/entrypoint.py
+++ b/workers/annotations/cellpose/entrypoint.py
@@ -10,9 +10,7 @@ from annotation_client.utils import sendError
 import girder_utils
 from girder_utils import MODELS_DIR
 
-from shapely.geometry import Polygon
-
-from worker_client import WorkerClient, geometry_to_polygon_coords
+from worker_client import WorkerClient, clean_polygon_coords
 
 BASE_MODELS = ['cyto', 'cyto2', 'cyto3', 'nuclei']
 
@@ -159,25 +157,22 @@ def run_model(image, cellpose, tile_size, tile_overlap, padding, smoothing):
     polygons = cellpose(image)
     polygons = stitch_polygons(polygons)
 
-    if padding != 0:
-        dilated_polygons = []
-        for polygon in polygons:
-            # A negative buffer (shrinking) can erode a small object away to an
-            # empty geometry or pinch it into a MultiPolygon, so normalize the
-            # result and drop anything that no longer forms a valid polygon.
-            dilated_polygon = Polygon(polygon).buffer(padding)
-            dilated_polygons.extend(geometry_to_polygon_coords(dilated_polygon))
-    else:
-        dilated_polygons = polygons
+    if padding == 0 and smoothing == 0:
+        return polygons
 
-    if smoothing > 0:
-        smoothed_polygons = []
-        for polygon in dilated_polygons:
-            smoothed_polygon = Polygon(polygon).simplify(smoothing)
-            smoothed_polygons.extend(geometry_to_polygon_coords(smoothed_polygon))
-        return smoothed_polygons
-    else:
-        return dilated_polygons
+    # clean_polygon_coords applies padding (buffer) then smoothing (simplify) and
+    # drops whatever does not survive: a contour too short to form a ring, a
+    # non-finite coordinate, an object eroded away by negative padding, or a
+    # MultiPolygon from an object pinched in two (each piece becomes its own
+    # annotation). Any of those raised or produced empty coordinates before,
+    # which failed the *entire* batch upload -- hundreds of good cells lost to
+    # one bad mask.
+    cleaned_polygons = []
+    for polygon in polygons:
+        cleaned_polygons.extend(clean_polygon_coords(
+            polygon, padding=padding, smoothing=smoothing))
+
+    return cleaned_polygons
 
 
 def compute(datasetId, apiUrl, token, params):

--- a/workers/annotations/cellposesam/CELLPOSESAM.md
+++ b/workers/annotations/cellposesam/CELLPOSESAM.md
@@ -58,7 +58,9 @@ Uses DeepTile to split images into square tiles with configurable size and overl
 
 ### Polygon Post-processing
 
-Applied in order: padding (via Shapely `buffer()`), then smoothing (via Shapely `simplify()`).
+Applied in order: padding (via Shapely `buffer()`), then smoothing (via Shapely `simplify()`), through the shared `clean_polygon_coords()` helper.
+
+Degenerate outlines are dropped rather than uploaded, because a single bad polygon used to fail the *entire* batch upload (server 400: `data.coordinates must contain at least 1 items`). Dropped cases: a contour too short to form a ring (a one-pixel-wide mask), a non-finite coordinate, and an object eroded to nothing by negative padding. An object pinched in two by negative padding becomes a `MultiPolygon`, and each piece is uploaded as its own annotation — so a frame's annotation count is not necessarily equal to the mask count.
 
 ## Notes
 

--- a/workers/annotations/cellposesam/entrypoint.py
+++ b/workers/annotations/cellposesam/entrypoint.py
@@ -10,9 +10,7 @@ from annotation_client.utils import sendError, sendWarning
 import girder_utils
 from girder_utils import MODELS_DIR
 
-from shapely.geometry import Polygon
-
-from worker_client import WorkerClient, geometry_to_polygon_coords
+from worker_client import WorkerClient, clean_polygon_coords
 
 from models_config import (
     BASE_MODELS, DEFAULT_MODEL, build_cellpose_parameters, build_model_items)
@@ -146,25 +144,22 @@ def run_model(image, cellpose, tile_size, tile_overlap, padding, smoothing):
     polygons = cellpose(image)
     polygons = stitch_polygons(polygons)
 
-    if padding != 0:
-        dilated_polygons = []
-        for polygon in polygons:
-            # A negative buffer (shrinking) can erode a small object away to an
-            # empty geometry or pinch it into a MultiPolygon, so normalize the
-            # result and drop anything that no longer forms a valid polygon.
-            dilated_polygon = Polygon(polygon).buffer(padding)
-            dilated_polygons.extend(geometry_to_polygon_coords(dilated_polygon))
-    else:
-        dilated_polygons = polygons
+    if padding == 0 and smoothing == 0:
+        return polygons
 
-    if smoothing > 0:
-        smoothed_polygons = []
-        for polygon in dilated_polygons:
-            smoothed_polygon = Polygon(polygon).simplify(smoothing)
-            smoothed_polygons.extend(geometry_to_polygon_coords(smoothed_polygon))
-        return smoothed_polygons
-    else:
-        return dilated_polygons
+    # clean_polygon_coords applies padding (buffer) then smoothing (simplify) and
+    # drops whatever does not survive: a contour too short to form a ring, a
+    # non-finite coordinate, an object eroded away by negative padding, or a
+    # MultiPolygon from an object pinched in two (each piece becomes its own
+    # annotation). Any of those raised or produced empty coordinates before,
+    # which failed the *entire* batch upload -- hundreds of good cells lost to
+    # one bad mask.
+    cleaned_polygons = []
+    for polygon in polygons:
+        cleaned_polygons.extend(clean_polygon_coords(
+            polygon, padding=padding, smoothing=smoothing))
+
+    return cleaned_polygons
 
 
 def compute(datasetId, apiUrl, token, params):

--- a/workers/annotations/cellposesam/tests/test_run_model.py
+++ b/workers/annotations/cellposesam/tests/test_run_model.py
@@ -1,0 +1,223 @@
+"""Unit tests for Cellpose-SAM's polygon post-processing (``run_model``).
+
+A production run failed with HTTP 400 ``data.coordinates must contain at least
+1 items``, which aborted the upload of *all* 442 annotations found in the frame.
+The upload chokepoint (``worker_client.create_polygon_annotations``) now drops
+degenerate geometry, but ``run_model`` itself builds shapely polygons *before*
+that chokepoint, and those constructions were unguarded:
+
+* a 1-2 point contour (a one-pixel-wide mask) makes ``Polygon()`` raise
+  ``ValueError: A linearring requires at least 4 coordinates``;
+* a contour carrying a non-finite coordinate makes ``.simplify()`` raise
+  ``GEOSException: Non-finite envelope bounds``.
+
+Either one kills the whole run, so a single bad mask out of hundreds loses every
+good annotation in the frame. These tests pin that one bad mask is skipped and
+the good ones still come through.
+
+``deeptile``/``cellpose`` are stubbed so this runs in the lightweight local venv
+without the GPU worker stack. Run with:
+
+    .cache/testvenv/bin/pytest workers/annotations/cellposesam/tests -q
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+from shapely.geometry import Polygon
+
+
+WORKER_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = WORKER_DIR.parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / stubs
+# ---------------------------------------------------------------------------
+
+def _stub_module(monkeypatch, name, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+@pytest.fixture
+def entrypoint(monkeypatch):
+    """Load cellposesam's entrypoint with its heavy dependencies stubbed out."""
+    # The in-repo copies of the shared packages, so the test exercises the code
+    # under review rather than whatever happens to be pip-installed.
+    monkeypatch.syspath_prepend(str(REPO_ROOT / 'annotation_utilities'))
+    monkeypatch.syspath_prepend(str(REPO_ROOT / 'worker_client'))
+    monkeypatch.syspath_prepend(str(WORKER_DIR))
+
+    # annotation_client is a server-side package; only interface()/compute()
+    # touch it, not run_model.
+    _stub_module(monkeypatch, 'annotation_client')
+    _stub_module(monkeypatch, 'annotation_client.workers',
+                 UPennContrastWorkerPreviewClient=lambda **kwargs: None)
+    _stub_module(monkeypatch, 'annotation_client.utils',
+                 sendError=lambda *a, **k: None,
+                 sendWarning=lambda *a, **k: None,
+                 sendProgress=lambda *a, **k: None)
+    _stub_module(monkeypatch, 'annotation_client.annotations',
+                 UPennContrastAnnotationClient=lambda **kwargs: None)
+    _stub_module(monkeypatch, 'annotation_client.tiles',
+                 UPennContrastDataset=lambda **kwargs: None)
+    for name in ('worker_client', 'worker_client.worker_client'):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+    # deeptile is imported lazily inside run_model; stub the tiling away so the
+    # test drives the polygon post-processing directly.
+    stitch = _stub_module(monkeypatch, 'deeptile.extensions.stitch',
+                          stitch_polygons=lambda polygons: polygons)
+    extensions = _stub_module(monkeypatch, 'deeptile.extensions', stitch=stitch)
+    _stub_module(monkeypatch, 'deeptile',
+                 load=lambda image: types.SimpleNamespace(
+                     get_tiles=lambda **kwargs: image),
+                 extensions=extensions)
+
+    spec = importlib.util.spec_from_file_location(
+        'cellposesam_entrypoint', WORKER_DIR / 'entrypoint.py')
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, 'cellposesam_entrypoint', module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run(entrypoint, contours, padding=0.0, smoothing=0.0):
+    """Run the post-processing pipeline over a fixed list of mask contours."""
+    return entrypoint.run_model(
+        image=np.zeros((4, 4), dtype=np.float32),
+        cellpose=lambda tiles: contours,
+        tile_size=1024,
+        tile_overlap=0.1,
+        padding=padding,
+        smoothing=smoothing,
+    )
+
+
+# A comfortably large, healthy cell outline that survives padding/smoothing.
+HEALTHY_CELL = [(0.0, 0.0), (20.0, 0.0), (20.0, 20.0), (0.0, 20.0)]
+
+
+def _assert_annotation_ready(rings):
+    """Every returned ring must be uploadable as a polygon annotation."""
+    for ring in rings:
+        coords = list(ring)
+        # An empty coordinate list is exactly what the server rejects with 400.
+        assert len(coords) >= 4
+        for point in coords:
+            x, y = point  # must unpack as 2D, or annotation building crashes
+            assert np.isfinite(x) and np.isfinite(y)
+
+
+# ---------------------------------------------------------------------------
+# The reported failure: one bad mask must not lose the whole frame
+# ---------------------------------------------------------------------------
+
+def test_two_point_contour_does_not_abort_the_frame(entrypoint):
+    """A 1px-wide mask cannot form a ring; skip it, keep the real cells."""
+    two_points = [(5.0, 5.0), (5.0, 6.0)]
+
+    rings = _run(entrypoint, [HEALTHY_CELL, two_points, HEALTHY_CELL],
+                 padding=-1.0, smoothing=0.7)
+
+    assert len(rings) == 2
+    _assert_annotation_ready(rings)
+
+
+def test_single_point_contour_does_not_abort_the_frame(entrypoint):
+    single_point = [(5.0, 5.0)]
+
+    rings = _run(entrypoint, [HEALTHY_CELL, single_point], padding=-1.0, smoothing=0.7)
+
+    assert len(rings) == 1
+    _assert_annotation_ready(rings)
+
+
+def test_non_finite_contour_does_not_abort_the_frame(entrypoint):
+    """A NaN coordinate makes simplify() raise GEOSException; skip that mask."""
+    nan_contour = [(0.0, 0.0), (np.nan, 5.0), (10.0, 10.0), (0.0, 10.0)]
+
+    rings = _run(entrypoint, [HEALTHY_CELL, nan_contour], padding=-1.0, smoothing=0.7)
+
+    assert len(rings) == 1
+    _assert_annotation_ready(rings)
+
+
+def test_smoothing_only_survives_degenerate_contours(entrypoint):
+    """Padding off, smoothing on -- the default interface configuration."""
+    rings = _run(entrypoint, [HEALTHY_CELL, [(1.0, 1.0), (2.0, 2.0)]],
+                 padding=0.0, smoothing=0.7)
+
+    assert len(rings) == 1
+    _assert_annotation_ready(rings)
+
+
+def test_padding_only_survives_degenerate_contours(entrypoint):
+    rings = _run(entrypoint, [HEALTHY_CELL, [(1.0, 1.0), (2.0, 2.0)]],
+                 padding=2.0, smoothing=0.0)
+
+    assert len(rings) == 1
+    _assert_annotation_ready(rings)
+
+
+def test_frame_of_only_degenerate_contours_returns_nothing(entrypoint):
+    """Nothing valid must yield an empty list, never an empty-coordinate ring."""
+    rings = _run(entrypoint, [[(1.0, 1.0), (2.0, 2.0)], [], [(0.0, 0.0)]],
+                 padding=-1.0, smoothing=0.7)
+
+    assert list(rings) == []
+
+
+# ---------------------------------------------------------------------------
+# Existing post-processing behavior must not regress
+# ---------------------------------------------------------------------------
+
+def test_negative_padding_drops_cells_eroded_to_nothing(entrypoint):
+    """Small objects shrunk away by negative padding are dropped, not uploaded."""
+    tiny = [(0.0, 0.0), (1.5, 0.0), (1.5, 1.5), (0.0, 1.5)]
+
+    rings = _run(entrypoint, [HEALTHY_CELL, tiny], padding=-1.0, smoothing=0.0)
+
+    assert len(rings) == 1
+    _assert_annotation_ready(rings)
+
+
+def test_negative_padding_splitting_a_cell_yields_both_pieces(entrypoint):
+    """A pinched cell becomes a MultiPolygon; each piece is its own annotation."""
+    dumbbell = [
+        (0, 0), (10, 0), (10, 4), (6, 4), (6, 5), (10, 5), (10, 9),
+        (0, 9), (0, 5), (4, 5), (4, 4), (0, 4),
+    ]
+    assert Polygon(dumbbell).buffer(-1.0).geom_type == 'MultiPolygon'
+
+    rings = _run(entrypoint, [dumbbell], padding=-1.0, smoothing=0.0)
+
+    assert len(rings) == 2
+    _assert_annotation_ready(rings)
+
+
+def test_no_padding_or_smoothing_passes_contours_through(entrypoint):
+    """With post-processing off, cellpose's own outlines reach the uploader."""
+    rings = _run(entrypoint, [HEALTHY_CELL], padding=0.0, smoothing=0.0)
+
+    assert len(rings) == 1
+    assert list(rings[0]) == HEALTHY_CELL
+
+
+def test_smoothing_reduces_vertex_count(entrypoint):
+    """Smoothing must still actually simplify the outline."""
+    jagged = [(0.0, 0.0), (10.0, 0.05), (20.0, 0.0), (20.0, 20.0),
+              (10.0, 19.95), (0.0, 20.0)]
+
+    rings = _run(entrypoint, [jagged], padding=0.0, smoothing=0.7)
+
+    assert len(rings) == 1
+    assert len(rings[0]) < len(jagged) + 1  # +1 for the closing vertex

--- a/workers/annotations/condensatenet/entrypoint.py
+++ b/workers/annotations/condensatenet/entrypoint.py
@@ -6,9 +6,7 @@ from functools import partial
 import annotation_client.workers as workers
 
 import numpy as np
-from shapely.geometry import Polygon
-
-from worker_client import WorkerClient, geometry_to_polygon_coords
+from worker_client import WorkerClient, clean_polygon_coords
 
 from annotation_client.utils import sendProgress
 
@@ -236,26 +234,21 @@ def run_model(image, condensatenet, tile_size, tile_overlap, padding, smoothing)
     polygons = condensatenet(tiles)
     polygons = stitch_polygons(polygons)
 
-    # Apply padding (dilation/erosion)
-    if padding != 0:
-        dilated_polygons = []
-        for polygon in polygons:
-            # A negative buffer (shrinking) can erode a small object away to an
-            # empty geometry or pinch it into a MultiPolygon, so normalize the
-            # result and drop anything that no longer forms a valid polygon.
-            dilated_polygon = Polygon(polygon).buffer(padding)
-            dilated_polygons.extend(geometry_to_polygon_coords(dilated_polygon))
-        polygons = dilated_polygons
-
-    # Apply smoothing
-    if smoothing > 0:
-        smoothed_polygons = []
-        for polygon in polygons:
-            smoothed_polygon = Polygon(polygon).simplify(smoothing, preserve_topology=True)
-            smoothed_polygons.extend(geometry_to_polygon_coords(smoothed_polygon))
-        return smoothed_polygons
-    else:
+    if padding == 0 and smoothing == 0:
         return polygons
+
+    # Apply padding (dilation/erosion) then smoothing. clean_polygon_coords drops
+    # whatever does not survive: a contour too short to form a ring, a non-finite
+    # coordinate, an object eroded away by negative padding, or a MultiPolygon
+    # from an object pinched in two (each piece becomes its own annotation). Any
+    # of those raised or produced empty coordinates before, which failed the
+    # *entire* batch upload -- hundreds of good objects lost to one bad mask.
+    cleaned_polygons = []
+    for polygon in polygons:
+        cleaned_polygons.extend(clean_polygon_coords(
+            polygon, padding=padding, smoothing=smoothing))
+
+    return cleaned_polygons
 
 
 def compute(datasetId, apiUrl, token, params):

--- a/workers/annotations/sam2_automatic_mask_generator/entrypoint.py
+++ b/workers/annotations/sam2_automatic_mask_generator/entrypoint.py
@@ -13,9 +13,7 @@ import annotation_utilities.annotation_tools as annotation_tools
 import annotation_utilities.batch_argument_parser as batch_argument_parser
 
 import numpy as np  # library for array manipulation
-from shapely.geometry import Polygon
 from skimage.measure import find_contours
-from shapely.geometry import Polygon
 
 
 from annotation_client.utils import sendProgress
@@ -137,8 +135,14 @@ def compute(datasetId, apiUrl, token, params):
         for mask_data in masks:
             mask = mask_data['segmentation']
             contours = find_contours(mask, 0.5)
-            polygon = Polygon(contours[0]).simplify(smoothing, preserve_topology=True)
-            if polygon.is_valid and not polygon.is_empty:
+            if not contours:  # nothing traceable in this mask
+                continue
+            # Guarded construction: a contour too short to form a ring raises
+            # ValueError and a non-finite coordinate makes simplify() raise
+            # GEOSException, either of which would abort the whole run.
+            polygon = annotation_tools.safe_simplify(
+                annotation_tools.safe_polygon(contours[0]), smoothing)
+            if polygon is not None and polygon.is_valid and not polygon.is_empty:
                 temp_polygons.append(polygon)
 
         temp_annotations = annotation_tools.polygons_to_annotations(temp_polygons, datasetId, XY=XY, Time=Time, Z=Z, tags=tags, channel=channel)

--- a/workers/annotations/sam2_fewshot_segmentation/entrypoint.py
+++ b/workers/annotations/sam2_fewshot_segmentation/entrypoint.py
@@ -13,7 +13,6 @@ import annotation_utilities.annotation_tools as annotation_tools
 import annotation_utilities.batch_argument_parser as batch_argument_parser
 
 import numpy as np
-from shapely.geometry import Polygon
 from skimage.measure import find_contours
 
 from annotation_client.utils import sendProgress, sendError
@@ -377,8 +376,10 @@ def compute(datasetId, apiUrl, token, params):
         coords = annotation['coordinates']
         rows = [c['y'] for c in coords]
         cols = [c['x'] for c in coords]
-        poly = Polygon(zip(cols, rows))
-        if poly.is_valid:
+        # A degenerate training annotation (too few points) would raise here and
+        # abort the run before inference even starts; skip it instead.
+        poly = annotation_tools.safe_polygon(list(zip(cols, rows)))
+        if poly is not None and poly.is_valid:
             training_areas.append(poly.area)
 
     mean_area = np.mean(training_areas) if training_areas else None
@@ -452,8 +453,12 @@ def compute(datasetId, apiUrl, token, params):
                 contours = find_contours(mask, 0.5)
                 if len(contours) == 0:
                     continue
-                polygon = Polygon(contours[0]).simplify(smoothing, preserve_topology=True)
-                if polygon.is_valid and not polygon.is_empty:
+                # Guarded construction: a contour too short to form a ring
+                # raises ValueError and a non-finite coordinate makes simplify()
+                # raise GEOSException, either of which would abort the whole run.
+                polygon = annotation_tools.safe_simplify(
+                    annotation_tools.safe_polygon(contours[0]), smoothing)
+                if polygon is not None and polygon.is_valid and not polygon.is_empty:
                     filtered_polygons.append(polygon)
 
         print(f"Frame {i + 1}: {len(filtered_polygons)} masks passed similarity filter")

--- a/workers/annotations/sam2_propagate/entrypoint.py
+++ b/workers/annotations/sam2_propagate/entrypoint.py
@@ -13,9 +13,7 @@ import annotation_utilities.annotation_tools as annotation_tools
 import annotation_utilities.batch_argument_parser as batch_argument_parser
 
 import numpy as np  # library for array manipulation
-from shapely.geometry import Polygon
 from skimage.measure import find_contours
-from shapely.geometry import Polygon
 
 
 from annotation_client.utils import sendProgress
@@ -148,9 +146,15 @@ def sam2_masks_to_polygons(masks, smoothing, padding):
             mask = mask.squeeze(0)
         contours = find_contours(mask, 0.5)
         if contours:  # Check if contours were found
-            polygon = Polygon(contours[0]).simplify(smoothing, preserve_topology=True)
-            polygon = polygon.buffer(padding)
-            polygons.append(polygon)
+            # A contour too short to form a ring raises ValueError, and a
+            # non-finite coordinate makes simplify() raise GEOSException; either
+            # would abort the whole run, so skip that mask instead (same as the
+            # no-contours case above).
+            polygon = annotation_tools.safe_polygon(contours[0])
+            polygon = annotation_tools.safe_simplify(polygon, smoothing)
+            polygon = annotation_tools.safe_buffer(polygon, padding)
+            if polygon is not None:
+                polygons.append(polygon)
     return polygons
 
 

--- a/workers/annotations/sam2_video/entrypoint.py
+++ b/workers/annotations/sam2_video/entrypoint.py
@@ -12,9 +12,7 @@ import annotation_utilities.annotation_tools as annotation_tools
 import annotation_utilities.batch_argument_parser as batch_argument_parser
 
 import numpy as np  # library for array manipulation
-from shapely.geometry import Polygon
 from skimage.measure import find_contours
-from shapely.geometry import Polygon
 
 
 from annotation_client.utils import sendProgress
@@ -322,7 +320,15 @@ def compute(datasetId, apiUrl, token, params):
                         contours = find_contours(mask.squeeze(), 0.5)
                         if len(contours) == 0:
                             continue
-                        polygon = Polygon(contours[0]).buffer(padding).simplify(smoothing, preserve_topology=True)
+                        # Guarded construction: a contour too short to form a
+                        # ring raises ValueError and a non-finite coordinate
+                        # makes simplify() raise GEOSException, either of which
+                        # would abort the whole run.
+                        polygon = annotation_tools.safe_buffer(
+                            annotation_tools.safe_polygon(contours[0]), padding)
+                        polygon = annotation_tools.safe_simplify(polygon, smoothing)
+                        if polygon is None:
+                            continue
                         # Create annotations
                         annotations = annotation_tools.polygons_to_annotations(polygon, datasetId, XY=XY, Z=Z, Time=Time_frame, tags=tags, channel=channel)
                         for annotation in annotations:
@@ -397,7 +403,15 @@ def compute(datasetId, apiUrl, token, params):
                         contours = find_contours(mask.squeeze(), 0.5)
                         if len(contours) == 0:
                             continue
-                        polygon = Polygon(contours[0]).buffer(padding).simplify(smoothing, preserve_topology=True)
+                        # Guarded construction: a contour too short to form a
+                        # ring raises ValueError and a non-finite coordinate
+                        # makes simplify() raise GEOSException, either of which
+                        # would abort the whole run.
+                        polygon = annotation_tools.safe_buffer(
+                            annotation_tools.safe_polygon(contours[0]), padding)
+                        polygon = annotation_tools.safe_simplify(polygon, smoothing)
+                        if polygon is None:
+                            continue
                         # Create annotations
                         annotations = annotation_tools.polygons_to_annotations(polygon, datasetId, XY=XY, Z=Z_frame, Time=Time, tags=tags, channel=channel)
                         for annotation in annotations:

--- a/workers/annotations/sam_automatic_mask_generator/entrypoint.py
+++ b/workers/annotations/sam_automatic_mask_generator/entrypoint.py
@@ -7,10 +7,10 @@ import annotation_client.annotations as annotations_client
 import annotation_client.workers as workers
 import annotation_client.tiles as tiles
 
+import annotation_utilities.annotation_tools as annotation_tools
+
 import numpy as np  # library for array manipulation
-from shapely.geometry import Polygon
 from skimage.measure import find_contours
-from shapely.geometry import Polygon
 
 
 
@@ -162,10 +162,14 @@ def compute(datasetId, apiUrl, token, params):
         contours = find_contours(mask, 0.5)
         
         for contour in contours:
-            # Simplify the contour to reduce the number of points
-            polygon = Polygon(contour).simplify(smoothing, preserve_topology=True)
-            
-            if polygon.is_valid and not polygon.is_empty:
+            # Simplify the contour to reduce the number of points. Guarded
+            # construction: a contour too short to form a ring raises ValueError
+            # and a non-finite coordinate makes simplify() raise GEOSException,
+            # either of which would abort the whole run.
+            polygon = annotation_tools.safe_simplify(
+                annotation_tools.safe_polygon(contour), smoothing)
+
+            if polygon is not None and polygon.is_valid and not polygon.is_empty:
                 # Convert the polygon coordinates to the required format
                 coordinates = [{"x": float(y), "y": float(x)} for x, y in polygon.exterior.coords]
                 

--- a/workers/annotations/sam_fewshot_segmentation/entrypoint.py
+++ b/workers/annotations/sam_fewshot_segmentation/entrypoint.py
@@ -12,7 +12,6 @@ import annotation_utilities.annotation_tools as annotation_tools
 import annotation_utilities.batch_argument_parser as batch_argument_parser
 
 import numpy as np
-from shapely.geometry import Polygon
 from skimage.measure import find_contours
 
 from annotation_client.utils import sendProgress, sendError
@@ -395,8 +394,10 @@ def compute(datasetId, apiUrl, token, params):
         coords = annotation['coordinates']
         rows = [c['y'] for c in coords]
         cols = [c['x'] for c in coords]
-        poly = Polygon(zip(cols, rows))
-        if poly.is_valid:
+        # A degenerate training annotation (too few points) would raise here and
+        # abort the run before inference even starts; skip it instead.
+        poly = annotation_tools.safe_polygon(list(zip(cols, rows)))
+        if poly is not None and poly.is_valid:
             training_areas.append(poly.area)
 
     mean_area = np.mean(training_areas) if training_areas else None
@@ -470,8 +471,12 @@ def compute(datasetId, apiUrl, token, params):
                 contours = find_contours(mask, 0.5)
                 if len(contours) == 0:
                     continue
-                polygon = Polygon(contours[0]).simplify(smoothing, preserve_topology=True)
-                if polygon.is_valid and not polygon.is_empty:
+                # Guarded construction: a contour too short to form a ring
+                # raises ValueError and a non-finite coordinate makes simplify()
+                # raise GEOSException, either of which would abort the whole run.
+                polygon = annotation_tools.safe_simplify(
+                    annotation_tools.safe_polygon(contours[0]), smoothing)
+                if polygon is not None and polygon.is_valid and not polygon.is_empty:
                     filtered_polygons.append(polygon)
 
         print(f"Frame {i + 1}: {len(filtered_polygons)} masks passed similarity filter")


### PR DESCRIPTION
## The bug

A Cellpose-SAM run died with:

```
HTTP error 400: POST .../upenn_annotation/multiple
{"message": "data.coordinates must contain at least 1 items", "type": "validation"}
```

Annotations upload as one batch, so a single bad polygon took all **442** cells found in that frame down with it.

`399df15` fixed the *upload chokepoints* for this — but only the code that runs **after** a shapely geometry exists. Construction itself was still bare, and that's where the cellpose-family workers build their geometry, before anything reaches a chokepoint:

* `Polygon(contour)` raises `ValueError: A linearring requires at least 4 coordinates` for a 1–2 point contour (a one-pixel-wide mask);
* a contour carrying a NaN/inf coordinate builds fine, then detonates inside `.simplify()` with `GEOSException: Non-finite envelope bounds` — which is **not** a `ValueError`, so it slips past a naive `except ValueError`.

Either one aborts the whole run, so one unusable mask out of hundreds still loses every good annotation in the frame. The failing run used `Padding: -1` and `Smoothing: 0.7`, i.e. both transform paths were live.

## The fix

New guarded helpers in `annotation_utilities.annotation_tools`, returning `None`/`[]` instead of raising:

| Helper | Purpose |
|---|---|
| `safe_polygon(coords)` | Build a `Polygon`, or `None`. Rejects too-short contours and non-finite coordinates, and drops a third coordinate column (a 3D ring yields 3-tuples, which break the `(x, y)` unpacking used to build annotation coordinates). |
| `safe_buffer` / `safe_simplify` | `None`-tolerant, GEOS-error-tolerant padding and smoothing. |
| `clean_polygon_coords(coords, padding, smoothing)` | The whole pipeline: contour → annotation-ready rings, padding then smoothing (the order the cellpose family has always used). |

`geometry_to_polygon_coords` also now rejects a NaN area (every NaN comparison is False, so `area <= 0` let it through) and survives GEOS errors raised by `is_valid`/`area`.

## Sweep

Every worker that builds a polygon from model output had the same latent crash:

* **cellposesam, cellpose, condensatenet** — `run_model` post-processing now goes through `clean_polygon_coords`. Behavior is unchanged for healthy outlines (same buffer-then-simplify order, `preserve_topology=True` as before).
* **sam2_video, sam2_propagate, sam/sam2 automatic-mask-generator, sam/sam2 few-shot** — guarded `safe_*` construction, preserving the skip-unusable behavior those functions already had for their no-contours case.
* **sam2_automatic_mask_generator** also indexed `contours[0]` without checking for an empty contour list — `IndexError` on a mask with nothing traceable.
* **sam/sam2 few-shot** computed training-area stats from user annotations, where one degenerate annotation aborted the run before inference started.
* **worker_client** — the upload chokepoint now uses `safe_polygon`, so it catches GEOS errors too (its `except (ValueError, TypeError)` did not); helpers are re-exported for workers.

Removed the now-unused `shapely.geometry.Polygon` imports (duplicated in several of these files).

**Deliberately not covered:** the `cellpose_train` / `cellposesam_train` region-polygon reads, where a degenerate *user* annotation can still abort a training run — a different surface (user input, not model output) and out of scope here. It's recorded in the hardening skill catalog, which gains the construction-time half of this failure mode.

## Tests (TDD: red → green)

`workers/annotations/cellposesam/tests/test_run_model.py` is new — this path had **no** coverage. `deeptile`/`cellpose` are stubbed so it runs natively in the light venv, no GPU image needed. 6 of its 10 tests reproduced the crash before the fix; the other 4 pin existing post-processing behavior (negative padding erosion, MultiPolygon splitting, pass-through, smoothing actually simplifying).

```
annotation_utilities:  35 passed   (+17 new)
worker_client:         15 passed   (+3 new)
cellposesam:           23 passed   (+10 new)
```

Docker worker tests were not run — no Docker in this environment. The pre-existing few-shot worker test suites need the in-image `annotation_client` and fail to collect natively both before and after this change.

`CELLPOSESAM.md` gains a note that degenerate outlines are dropped and that a pinched object yields one annotation per piece, so a frame's annotation count need not equal its mask count.

---
_Generated by [Claude Code](https://claude.ai/code/session_012j37xD35rbyXcHmLPJ6Knq)_