### PR TITLE
perf(workers): slim the remaining ML images via real multi-stage builds

### DIFF
--- a/todo/TODO_REGISTRY.md
+++ b/todo/TODO_REGISTRY.md
@@ -14,7 +14,7 @@ Master index of deferred work, technical debt, and future improvements for the I
 |----|-------|--------|----------|------|------------|
 | TODO-001 | ML worker build optimization (mamba + shared base images) | Deferred | Medium | [ml-worker-build-optimization.md](ml-worker-build-optimization.md) | [#132](https://github.com/arjunrajlaboratory/ImageAnalysisProject/pull/132) |
 | TODO-002 | Worker startup latency audit & slimming plan (drop `conda run`) | In progress (#1–#3 done & verified; GPU workers static-validated, need build-host validation) | High | [worker-startup-latency.md](worker-startup-latency.md) | — |
-| TODO-003 | SAM/SAM2 worker image size (35–40 GB → est. 10–12 GB) | In progress (Dockerfiles rewritten; **not yet built or measured**) | Medium | [ml-worker-image-size.md](ml-worker-image-size.md) | — |
+| TODO-003 | ML worker image size (multi-stage builds across the GPU fleet) | In progress (wave 1 SAM/SAM2 merged; wave 2 cellpose ×4 / stardist / condensatenet / piscis ×2 rewritten but **not yet built or measured**; `deconwolf` still to do) | Medium | [ml-worker-image-size.md](ml-worker-image-size.md) | [#160](https://github.com/arjunrajlaboratory/ImageAnalysisProject/pull/160) |
 | TODO-004 | `channelCheckboxes` list-shaped values: identify the submitter, repair saved configs | Open (workers hardened and now reject the shape; front end surveyed, submitter unidentified) | Medium | [channelcheckboxes-serialization.md](channelcheckboxes-serialization.md) | [#162](https://github.com/arjunrajlaboratory/ImageAnalysisProject/pull/162) |
 
 ## Completed TODOs

--- a/todo/ml-worker-image-size.md
+++ b/todo/ml-worker-image-size.md
@@ -1,8 +1,14 @@
-# TODO-003: SAM / SAM2 Worker Image Size
+# TODO-003: ML Worker Image Size
 
-**Status:** Partially resolved — Dockerfile changes landed, **not yet built or measured**
+**Status:** SAM/SAM2 wave merged (PR #160). Second wave (cellpose ×4, stardist,
+condensatenet, piscis ×2) — Dockerfile changes landed, **not yet built or
+measured**
 **Priority:** Medium
 **Related:** [TODO-001 — ML Worker Build Optimization](ml-worker-build-optimization.md)
+
+---
+
+# Wave 1 — SAM / SAM2 (merged, PR #160)
 
 ## Problem
 
@@ -131,4 +137,142 @@ measurement. Before merging:
   whatever is newest on PyPI, which is a size *and* reproducibility hazard.
 - **The same pattern applies to the other GPU workers** (cellpose, cellposesam,
   stardist, condensatenet, piscis, deconwolf), which share the `devel`-base and
-  `r-base` copy-paste lineage.
+  `r-base` copy-paste lineage. → done for all but `deconwolf`, see wave 2 below.
+
+---
+
+# Wave 2 — cellpose ×4, stardist, condensatenet, piscis ×2
+
+## Scope
+
+The eight remaining images built by `build_machine_learning_workers.sh`:
+
+| Worker | Image |
+|---|---|
+| `cellpose` | `annotations/cellpose_worker` |
+| `cellpose_train` | `annotations/cellpose_train_worker` |
+| `cellposesam` | `annotations/cellposesam_worker` |
+| `cellposesam_train` | `annotations/cellposesam_train_worker` |
+| `stardist` | `annotations/stardist_worker` |
+| `condensatenet` | `annotations/condensatenet` |
+| `piscis/predict` | `annotations/piscis_predict` |
+| `piscis/train` | `annotations/piscis_train` |
+
+All eight carried the exact lineage wave 1 diagnosed: a `*-devel` CUDA base, a
+no-op `FROM base as build`, no `PIP_NO_CACHE_DIR`, no `conda clean`, full-history
+git clones, and the copy-pasted `r-base` (listed **twice**) +
+`software-properties-common` + `python3` apt block that no worker uses.
+
+## What was done
+
+Same shape as wave 1, per worker:
+
+1. **Real multi-stage build.** The `build` stage keeps the `devel` image (it is
+   the only compiler available for any source-only pip dependency); the runtime
+   stage ships on `*-runtime` and copies over the finished conda env, the trees
+   that were `pip install -e`'d, and the baked-in model cache. Worker `.py`
+   files are copied into the runtime stage directly from the build context.
+2. **`ENV PIP_NO_CACHE_DIR=1`** and **`conda clean --all --yes`**.
+3. **Dropped `r-base` ×2, `software-properties-common`, `python3-software-properties`
+   and `python3`** — nothing in these workers uses R or the system interpreter
+   (`run_worker.sh` execs the conda env's python directly).
+4. **Shallow clones** (`--depth 1`) with `.git` removed.
+5. **Pruned the DeepTile checkout** (cellpose, cellposesam, stardist,
+   condensatenet). The clone is ~140 MB but the importable package is 160 KB:
+   the rest is `.git` (50 MB), sample `data` (56 MB) and `notebooks` (37 MB).
+   It is a `pip install -e`, so the tree has to survive into the runtime stage —
+   `data`/`notebooks`/`tests` are deleted right after the clone instead.
+   Verified safe: DeepTile pins a static `version = "2.0.10"` in
+   `pyproject.toml`, so nothing needs `.git` at install time. (Same check for
+   `zjniu/Piscis`, which pins `version = '1.1.0'`.)
+
+Unlike wave 1, **no `environment.yml` was touched**: none of these workers had
+a dependency that was provably unused, and the two cellpose pairs / the two
+piscis images intentionally differ.
+
+### Per-worker specifics
+
+- **cellpose, cellpose_train, cellposesam, cellposesam_train** — runtime base is
+  plain `nvidia/cuda:11.8.0-runtime-ubuntu22.04`, i.e. the `cudnn8` tag is
+  dropped as well. cellpose takes torch from PyPI, whose wheel bundles its own
+  cuDNN / cuBLAS / cuFFT / NCCL under `site-packages` and dlopens those, so the
+  image's copy was never loaded. Model cache: `/root/.cellpose` — both cellpose
+  3.x and 4.x resolve checkpoints from `~/.cellpose/models`
+  (`models.MODEL_DIR`), which is where `download_models.py` writes. The
+  `.cellposesam` directory the two Cellpose-SAM workers use for Girder-synced
+  custom models is created at runtime and is deliberately *not* baked in.
+- **stardist** — the one worker that **keeps** `cudnn8` on the runtime stage.
+  TensorFlow 2.11 predates the `tensorflow[and-cuda]` extra (added in 2.14), so
+  its wheel declares no `nvidia-*` dependencies and dlopens `libcudnn.so.8`,
+  `libcublas`, `libcufft` from the *image*. A plain `-runtime` tag would not
+  fail the build: TF logs "Could not load dynamic library libcudnn.so.8" and
+  silently falls back to CPU. Model cache: `/root/.keras` (csbdeep's
+  `from_pretrained` → `keras.utils.get_file` → `~/.keras/models`).
+- **condensatenet** — runtime base `nvidia/cuda:12.1.0-runtime-ubuntu22.04`
+  (torch, so no `cudnn` tag needed). Model cache: `/models`, which is
+  self-contained — `download_model()` calls `snapshot_download(...,
+  local_dir_use_symlinks=False)`, so those are real files, not links into
+  `~/.cache/huggingface`.
+- **piscis (predict + train)** — runtime base
+  `nvidia/cuda:12.4.1-runtime-ubuntu22.04`. Model cache: `/root/.piscis`
+  (`piscis.paths.MODELS_DIR`); both workers also write user/trained models there
+  at runtime. Two extra fixes here:
+  - Both images ran `git clone https://github.com/arjunrajlaboratory/ImageAnalysisProject/`
+    and installed `annotation_utilities` / `worker_client` **from that clone**,
+    so the build used whatever was on the default branch rather than the tree
+    being built — the same bug wave 1 fixed in `sam_automatic_mask_generator`.
+    They now `COPY ./annotation_utilities` and `./worker_client` like every
+    other worker.
+  - Miniconda → Miniforge, matching every other worker. That removes the
+    `conda tos accept --channel https://repo.anaconda.com/pkgs/{main,r}` calls
+    and the `defaults` channel entirely. Safe here because
+    `piscis/environment.yml` is only `python=3.11` + `pip`.
+
+## Not yet verified
+
+**None of this has been built** — same constraint as wave 1 (no Docker daemon in
+the environment where the change was made). Before merging:
+
+1. `./build_machine_learning_workers.sh` and record `docker images` sizes
+   before/after for the eight images above.
+2. Per worker, confirm the model cache survived the stage copy and that no
+   download happens on first run:
+   - cellpose ×4: `ls /root/.cellpose/models` → `cyto/cyto2/cyto3/nuclei`
+     (cellpose 3) or `cpsam_v2`/`cpsam` (cellpose 4).
+   - stardist: `ls /root/.keras/models` → `2D_versatile_fluo`,
+     `2D_versatile_he`.
+   - condensatenet: `ls /models/condensatenet /models/condensatenet-v1` →
+     `config.json` + `model.safetensors` in each.
+   - piscis ×2: `ls /root/.piscis/models` → the four dated models plus the
+     `rajlab/raj-lab-piscis-models` collection.
+3. Confirm the GPU is actually used from the `runtime` base — not just that the
+   job completes. `torch.cuda.is_available()` for the seven torch workers, and
+   for stardist `tf.config.list_physical_devices('GPU')` **plus** a check that
+   the log has no "Could not load dynamic library libcudnn" line, since TF
+   degrades to CPU silently.
+4. Run one real job per worker (segmentation for cellpose/cellposesam/stardist/
+   condensatenet, spot detection for piscis predict, and a short retrain for the
+   three training workers, which is the path that writes into the copied model
+   directories).
+
+## Remaining opportunities (wave 2)
+
+- **`deconwolf` is the last GPU worker on this lineage** and was left out of
+  this pass: it is an image-processing worker rather than an ML one, and it is
+  the only one that compiles a native binary (`cmake` build of `elgw/deconwolf`
+  against fftw/gsl/png/tiff + the OpenCL loader). Splitting it needs the runtime
+  stage to install the non-`-dev` runtime libs and copy `/usr/bin/dw`, and its
+  `tests/Dockerfile_Test` still calls `conda run`, which would have to move to
+  `run_worker.sh` the way the two SAM test images did. It should be a bigger
+  win than most (it drops `cmake` + `build-essential` + six `-dev` packages),
+  and it does not need the CUDA *runtime* libs at all — it reaches the GPU via
+  `libnvidia-opencl.so.1`, which the Container Toolkit mounts from the host.
+- **`nvidia/cuda:*-base` for the torch workers.** None of them link against the
+  image's `libcudart` at all (torch loads its own), so unlike the SAM workers
+  there is no `_C.so` argument for keeping `-runtime`. Worth another ~1.5–2 GB
+  each, and it is a one-word change once wave 2 is measured.
+- **`condensatenet` has no `Dockerfile_M1`**, but
+  `build_machine_learning_workers.sh` passes `$DOCKERFILE` (= `Dockerfile_M1` on
+  arm64) for it. Pre-existing; an arm64 run of that script fails on this worker.
+- **Pin `torch` / `tensorflow`** in the cellpose and piscis environments for the
+  same reproducibility reason recorded in wave 1.

--- a/todo/ml-worker-image-size.md
+++ b/todo/ml-worker-image-size.md
@@ -227,6 +227,44 @@ piscis images intentionally differ.
     `conda tos accept --channel https://repo.anaconda.com/pkgs/{main,r}` calls
     and the `defaults` channel entirely. Safe here because
     `piscis/environment.yml` is only `python=3.11` + `pip`.
+  - **`libgl1 libglib2.0-0 libsm6 libice6 libx11-6 libxext6` are now installed
+    explicitly, in both stages.** See "The r-base trap" below.
+
+## The r-base trap (caught in review, applies to `deconwolf` next)
+
+Dropping the copy-pasted `r-base` is not purely cosmetic. `r-base-core`
+*depends on* `libglib2.0-0`, `libx11-6`, `libxt6` (→ `libsm6`, `libice6`),
+`libtk8.6` (→ `libxext6`), `libcairo2` (→ `libxcb1`) and `libgomp1` — so for
+four years every worker with `r-base` in its apt list has been getting those
+shared libraries by accident. Removing it removes them.
+
+That matters exactly once here: `piscis` depends on `opencv-python`, **not**
+`opencv-python-headless`, and `piscis/transforms.py` does `import cv2 as cv` at
+module scope. `cv2` links (via the Qt5 libs vendored in the wheel)
+`libGL.so.1`, `libglib-2.0.so.0`, `libgthread-2.0.so.0`, `libX11.so.6`,
+`libSM.so.6`, `libICE.so.6`, `libXext.so.6` and `libxcb.so.1`. Without them
+`import piscis` raises `ImportError` — in the **build** stage too, since
+`download_models.py` imports the package.
+
+Checked and cleared for the rest of the fleet by reading `DT_NEEDED` off every
+wheel's `.so` files against what the wheel vendors:
+
+| Wheel | Needs from the image |
+|---|---|
+| `opencv-python` (piscis) | libGL, libglib/libgthread, libX11, libSM, libICE, libXext, libxcb |
+| `opencv-python-headless` (cellpose ×4) | nothing beyond glibc/libstdc++ (`libz.so.1`, always present) |
+| `torch` | nothing — vendors its own libgomp and the whole CUDA stack |
+| `tensorflow==2.11.0` (stardist) | nothing linked; **dlopens** libcudnn.so.8 by name, hence the `cudnn8` runtime tag |
+| `stardist==0.9.1` | nothing beyond glibc/libstdc++ |
+| `rtree`, `shapely` | nothing — vendor libspatialindex / GEOS |
+
+`libgomp1` is safe to lose everywhere: conda-forge ships `libgomp` *inside* the
+env, and the torch wheels vendor their own.
+
+The lesson for `deconwolf`: it links fftw/gsl/png/tiff/OpenCL directly, so its
+runtime stage needs the non-`-dev` versions of those installed deliberately —
+`ldd /usr/bin/dw` in the build stage is the way to get the list, rather than
+assuming the base image carries them.
 
 ## Not yet verified
 

--- a/todo/ml-worker-image-size.md
+++ b/todo/ml-worker-image-size.md
@@ -266,32 +266,92 @@ runtime stage needs the non-`-dev` versions of those installed deliberately —
 `ldd /usr/bin/dw` in the build stage is the way to get the list, rather than
 assuming the base image carries them.
 
-## Not yet verified
+## `ptxas` / `nvcc` are gone from the runtime stage (measured, accepted)
 
-**None of this has been built** — same constraint as wave 1 (no Docker daemon in
-the environment where the change was made). Before merging:
+The CUDA *devel* images ship the toolkit binaries under `/usr/local/cuda/bin`;
+the `*-runtime` images do not. So every worker in this wave loses `ptxas`,
+`nvcc`, `cuobjdump` and friends. Confirmed on the built images: `which ptxas`
+resolves in the old `stardist_worker`, and finds nothing in the new one.
 
-1. `./build_machine_learning_workers.sh` and record `docker images` sizes
-   before/after for the eight images above.
-2. Per worker, confirm the model cache survived the stage copy and that no
-   download happens on first run:
-   - cellpose ×4: `ls /root/.cellpose/models` → `cyto/cyto2/cyto3/nuclei`
-     (cellpose 3) or `cpsam_v2`/`cpsam` (cellpose 4).
-   - stardist: `ls /root/.keras/models` → `2D_versatile_fluo`,
-     `2D_versatile_he`.
-   - condensatenet: `ls /models/condensatenet /models/condensatenet-v1` →
-     `config.json` + `model.safetensors` in each.
-   - piscis ×2: `ls /root/.piscis/models` → the four dated models plus the
-     `rajlab/raj-lab-piscis-models` collection.
-3. Confirm the GPU is actually used from the `runtime` base — not just that the
-   job completes. `torch.cuda.is_available()` for the seven torch workers, and
-   for stardist `tf.config.list_physical_devices('GPU')` **plus** a check that
-   the log has no "Could not load dynamic library libcudnn" line, since TF
-   degrades to CPU silently.
-4. Run one real job per worker (segmentation for cellpose/cellposesam/stardist/
-   condensatenet, spot detection for piscis predict, and a short retrain for the
-   three training workers, which is the path that writes into the copied model
-   directories).
+This is visible in exactly one place. **stardist** (TensorFlow) logs, on every
+run:
+
+```
+Couldn't get ptxas version string: INTERNAL: Couldn't invoke ptxas --version
+Failed to launch ptxas
+Relying on driver to perform ptx compilation.
+```
+
+TF wants `ptxas` to JIT-compile PTX and to run the redzone-checked autotuning
+pass when picking conv algorithms. Without it, it falls back to letting the
+driver compile PTX, which still works — a real segmentation on the RTX 3060
+returned the correct object count with cuDNN 8906 loaded and the GPU in use.
+The cost is the autotune redzone check being skipped and a possible first-call
+JIT slowdown, not wrong output. Accepted rather than fixed: pulling `cuda-nvcc`
+into the runtime stage would add back a few hundred MB to save log noise.
+
+**The seven torch workers are unaffected**, and not because they never JIT: the
+`triton` wheel bundles its own copy at
+`site-packages/triton/backends/nvidia/bin/ptxas`, so `torch.compile` finds one
+regardless of the base image. Anything that shells out to the *image's*
+`ptxas`, though, would now fail — worth remembering before adding a worker that
+compiles kernels at runtime.
+
+Note this interacts with the "`nvidia/cuda:*-base` for the torch workers" idea
+below: `-base` drops even more of the toolkit, so that change should be
+re-checked against this same question rather than assumed safe.
+
+## Verification (built and measured 2026-08-01)
+
+Built on x86_64 with an RTX 3060 (driver CUDA 13.0), against a live NimbusImage
+stack. Sizes are `docker image inspect .Size`, i.e. unpacked and base-10.
+
+| Worker | Before | After | Saved |
+|---|---:|---:|---:|
+| cellpose | 25.23 G | 8.87 G | −65% |
+| cellpose_train | 25.07 G | 8.88 G | −65% |
+| cellposesam | 23.21 G | 11.21 G | −52% |
+| cellposesam_train | 23.05 G | 11.22 G | −51% |
+| stardist | 20.44 G | 6.69 G | −67% |
+| condensatenet | 24.09 G | 8.28 G | −66% |
+| piscis/predict | 18.53 G | 8.71 G | −53% |
+| piscis/train | 18.87 G | 8.82 G | −53% |
+| **Fleet** | **178.5 G** | **72.7 G** | **−105.8 G (59%)** |
+
+The pre-change estimates in the PR that introduced this wave were written
+without a Docker daemon and overstated the baseline (they guessed a 215 G fleet
+and a 55% cut); the percentage was conservative, the absolute saving was not.
+Build times were 136–293 s per worker. **Compressed pull sizes were never
+measured** — every figure here is unpacked.
+
+Confirmed per worker:
+
+1. Model caches survived the stage copy, and no download happens on first run —
+   `/root/.cellpose/models` (`cyto*`/`nuclei*` for cellpose 3, `cpsam`+`cpsam_v2`
+   for cellpose 4), `/root/.keras/models/StarDist2D`, `/models/condensatenet-v1`,
+   `/root/.piscis/models` (four dated models + the `rajlab` collection).
+2. The GPU is genuinely used from the `runtime` base:
+   `torch.cuda.is_available()` is true for the seven torch workers, and stardist
+   reports `[PhysicalDevice('/physical_device:GPU:0')]` with `Loaded cuDNN
+   version 8906` and **no** "Could not load dynamic library libcudnn" line.
+3. `import cv2` succeeds inside both piscis images — the check that would have
+   caught the r-base trap above.
+4. Real jobs on a 5-channel dataset, all writing annotations back to Girder:
+   cellposesam (17 objects), stardist (17), cellpose (12), condensatenet (7976
+   condensates), piscis predict (spots on a synthetic field). cellposesam was
+   additionally run through the NimbusImage UI, whose job log shows
+   `runtime: nvidia` — so the `isGPUWorker` label still routes to the GPU queue
+   through girder_worker.
+5. Both training workers: GPU visible, checkpoints present, the copied model
+   directory is **writable**, and `from cellpose import train` imports.
+
+### Still not verified
+
+**An actual retrain.** Items above cover the preconditions (writable copied
+model dir, `train` importable) but no training run was executed, so nothing has
+yet written a real checkpoint into a directory that now arrives via
+`COPY --from`. This is the weakest point in the wave-2 verification and is worth
+doing the next time a training dataset is at hand.
 
 ## Remaining opportunities (wave 2)
 

--- a/workers/annotations/cellpose/Dockerfile
+++ b/workers/annotations/cellpose/Dockerfile
@@ -1,23 +1,37 @@
-FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04 as base
-LABEL isUPennContrastWorker=True
-LABEL com.nvidia.volumes.needed="nvidia_driver"
+# ---------------------------------------------------------------------------
+# Multi-stage build (see todo/ml-worker-image-size.md).
+#
+# Nothing in this worker compiles a CUDA extension -- cellpose is pure Python on
+# top of PyTorch -- so the CUDA *devel* image only serves to give the build stage
+# a compiler for any source-only pip dependency. The runtime stage ships on the
+# much smaller CUDA *runtime* image and copies over just the finished conda env,
+# the trees that are pip-installed in editable mode, and the model cache.
+#
+# The previous `FROM base as build` was a no-op: nothing was ever copied between
+# stages, so the toolchain, the miniforge installer, the pip wheel cache and the
+# conda package cache all stayed in the shipped image.
+#
+# PyTorch never uses the base image's CUDA libraries: it loads the cuDNN /
+# cuBLAS / cuFFT / NCCL shipped inside its own `nvidia-*` pip wheels under
+# site-packages. That is why the runtime stage does not need a `cudnn` tag.
+# ---------------------------------------------------------------------------
+FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04 AS build
 
-ENV NVIDIA_VISIBLE_DEVICES all
-ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+# pip's wheel cache is a full second copy of the torch + nvidia-* wheels
+# (~4 GB) and is worthless inside an image.
+ENV PIP_NO_CACHE_DIR=1
 
+# Build-time toolchain only; none of this is carried into the runtime stage.
+# `r-base` (listed twice) and `software-properties-common` were never used.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qy tzdata && \
-  apt-get install -qy software-properties-common python3-software-properties && \
-  apt-get update && apt-get install -qy \
+  apt-get install -qy \
   build-essential \
   wget \
-  python3 \
-  r-base \
+  git \
   libffi-dev \
   libssl-dev \
   libjpeg-dev \
   zlib1g-dev \
-  r-base \
-  git \
   libpython3-dev && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -30,33 +44,70 @@ RUN wget \
     && bash Miniforge3-Linux-x86_64.sh -b \
     && rm -f Miniforge3-Linux-x86_64.sh
 
-FROM base as build
-
 COPY ./workers/annotations/cellpose/environment.yml /
 RUN conda env create --file /environment.yml
 SHELL ["conda", "run", "-n", "worker", "/bin/bash", "-c"]
 
-RUN git clone https://github.com/arjunrajlaboratory/DeepTile
+# Shallow clones: full history is dead weight in an image. The DeepTile checkout
+# is ~140 MB but the importable package is 160 KB -- the rest is .git, sample
+# `data` (56 MB) and `notebooks` (37 MB). It is installed editable, so the tree
+# has to survive into the runtime stage; prune it here rather than ship it.
+RUN git clone --depth 1 https://github.com/arjunrajlaboratory/DeepTile && \
+    rm -rf /DeepTile/.git /DeepTile/data /DeepTile/notebooks /DeepTile/tests
 RUN pip install -e /DeepTile
 RUN pip install rtree shapely
 
-RUN git clone https://github.com/Kitware/UPennContrast/
+RUN git clone --depth 1 https://github.com/Kitware/UPennContrast/ && rm -rf /UPennContrast/.git
 
 RUN pip install -r /UPennContrast/devops/girder/annotation_client/requirements.txt
 RUN pip install -e /UPennContrast/devops/girder/annotation_client/
 
+# Bakes the built-in checkpoints into ~/.cellpose/models so the first run does
+# not have to download them. That directory is copied into the runtime stage.
 COPY ./workers/annotations/cellpose/download_models.py /
 RUN python /download_models.py
-
-COPY ./workers/annotations/cellpose/utils.py /
-COPY ./workers/annotations/cellpose/girder_utils.py /
-COPY ./workers/annotations/cellpose/entrypoint.py /
 
 COPY ./annotation_utilities /annotation_utilities
 RUN pip install /annotation_utilities
 
 COPY ./worker_client /worker_client
 RUN pip install /worker_client
+
+# Drop conda's package cache / tarballs -- another full copy of the env.
+RUN conda clean --all --yes
+
+# ---------------------------------------------------------------------------
+# Runtime stage
+# ---------------------------------------------------------------------------
+FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04
+
+LABEL isUPennContrastWorker=True
+LABEL com.nvidia.volumes.needed="nvidia_driver"
+
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qy \
+  tzdata \
+  ca-certificates && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/root/miniforge3/envs/worker/bin:$PATH"
+
+# The finished conda env, plus every tree that was pip-installed with `-e` and
+# therefore has to stay at its build-time path. Only the annotation_client
+# subtree is needed from the UPennContrast checkout, not the whole repo. Note
+# that `conda` itself is deliberately not copied -- run_worker.sh activates the
+# env by path, so the base conda install is build-time only.
+COPY --from=build /root/miniforge3/envs/worker /root/miniforge3/envs/worker
+COPY --from=build /UPennContrast/devops/girder/annotation_client /UPennContrast/devops/girder/annotation_client
+COPY --from=build /DeepTile /DeepTile
+# cellpose resolves checkpoints from ~/.cellpose/models (models.MODEL_DIR).
+COPY --from=build /root/.cellpose /root/.cellpose
+
+COPY ./workers/annotations/cellpose/utils.py /
+COPY ./workers/annotations/cellpose/girder_utils.py /
+COPY ./workers/annotations/cellpose/entrypoint.py /
 
 LABEL isUPennContrastWorker=True \
       isGPUWorker="true" \

--- a/workers/annotations/cellpose_train/Dockerfile
+++ b/workers/annotations/cellpose_train/Dockerfile
@@ -1,23 +1,37 @@
-FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04 as base
-LABEL isUPennContrastWorker=True
-LABEL com.nvidia.volumes.needed="nvidia_driver"
+# ---------------------------------------------------------------------------
+# Multi-stage build (see todo/ml-worker-image-size.md).
+#
+# Nothing in this worker compiles a CUDA extension -- cellpose is pure Python on
+# top of PyTorch -- so the CUDA *devel* image only serves to give the build stage
+# a compiler for any source-only pip dependency. The runtime stage ships on the
+# much smaller CUDA *runtime* image and copies over just the finished conda env,
+# the trees that are pip-installed in editable mode, and the model cache.
+#
+# The previous `FROM base as build` was a no-op: nothing was ever copied between
+# stages, so the toolchain, the miniforge installer, the pip wheel cache and the
+# conda package cache all stayed in the shipped image.
+#
+# PyTorch never uses the base image's CUDA libraries: it loads the cuDNN /
+# cuBLAS / cuFFT / NCCL shipped inside its own `nvidia-*` pip wheels under
+# site-packages. That is why the runtime stage does not need a `cudnn` tag.
+# ---------------------------------------------------------------------------
+FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04 AS build
 
-ENV NVIDIA_VISIBLE_DEVICES all
-ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+# pip's wheel cache is a full second copy of the torch + nvidia-* wheels
+# (~4 GB) and is worthless inside an image.
+ENV PIP_NO_CACHE_DIR=1
 
+# Build-time toolchain only; none of this is carried into the runtime stage.
+# `r-base` (listed twice) and `software-properties-common` were never used.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qy tzdata && \
-  apt-get install -qy software-properties-common python3-software-properties && \
-  apt-get update && apt-get install -qy \
+  apt-get install -qy \
   build-essential \
   wget \
-  python3 \
-  r-base \
+  git \
   libffi-dev \
   libssl-dev \
   libjpeg-dev \
   zlib1g-dev \
-  r-base \
-  git \
   libpython3-dev && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -30,31 +44,64 @@ RUN wget \
     && bash Miniforge3-Linux-x86_64.sh -b \
     && rm -f Miniforge3-Linux-x86_64.sh
 
-FROM base as build
-
 COPY ./workers/annotations/cellpose_train/environment.yml /
 RUN conda env create --file /environment.yml
 SHELL ["conda", "run", "-n", "worker", "/bin/bash", "-c"]
 
 RUN pip install rtree shapely
 
-RUN git clone https://github.com/Kitware/UPennContrast/
+# Shallow clone: full history is dead weight in an image.
+RUN git clone --depth 1 https://github.com/Kitware/UPennContrast/ && rm -rf /UPennContrast/.git
 
 RUN pip install -r /UPennContrast/devops/girder/annotation_client/requirements.txt
 RUN pip install -e /UPennContrast/devops/girder/annotation_client/
 
+# Bakes the built-in checkpoints into ~/.cellpose/models so the first run does
+# not have to download them. That directory is copied into the runtime stage.
 COPY ./workers/annotations/cellpose_train/download_models.py /
 RUN python /download_models.py
-
-COPY ./workers/annotations/cellpose_train/utils.py /
-COPY ./workers/annotations/cellpose_train/girder_utils.py /
-COPY ./workers/annotations/cellpose_train/entrypoint.py /
 
 COPY ./annotation_utilities /annotation_utilities
 RUN pip install /annotation_utilities
 
 COPY ./worker_client /worker_client
 RUN pip install /worker_client
+
+# Drop conda's package cache / tarballs -- another full copy of the env.
+RUN conda clean --all --yes
+
+# ---------------------------------------------------------------------------
+# Runtime stage
+# ---------------------------------------------------------------------------
+FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04
+
+LABEL isUPennContrastWorker=True
+LABEL com.nvidia.volumes.needed="nvidia_driver"
+
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qy \
+  tzdata \
+  ca-certificates && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/root/miniforge3/envs/worker/bin:$PATH"
+
+# The finished conda env, plus every tree that was pip-installed with `-e` and
+# therefore has to stay at its build-time path. Only the annotation_client
+# subtree is needed from the UPennContrast checkout, not the whole repo. Note
+# that `conda` itself is deliberately not copied -- run_worker.sh activates the
+# env by path, so the base conda install is build-time only.
+COPY --from=build /root/miniforge3/envs/worker /root/miniforge3/envs/worker
+COPY --from=build /UPennContrast/devops/girder/annotation_client /UPennContrast/devops/girder/annotation_client
+# cellpose resolves checkpoints from ~/.cellpose/models (models.MODEL_DIR). This
+# worker also writes its retrained models there at runtime.
+COPY --from=build /root/.cellpose /root/.cellpose
+
+COPY ./workers/annotations/cellpose_train/utils.py /
+COPY ./workers/annotations/cellpose_train/girder_utils.py /
+COPY ./workers/annotations/cellpose_train/entrypoint.py /
 
 LABEL isUPennContrastWorker="" \
       isGPUWorker="true" \

--- a/workers/annotations/cellposesam/Dockerfile
+++ b/workers/annotations/cellposesam/Dockerfile
@@ -1,23 +1,37 @@
-FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04 as base
-LABEL isUPennContrastWorker=True
-LABEL com.nvidia.volumes.needed="nvidia_driver"
+# ---------------------------------------------------------------------------
+# Multi-stage build (see todo/ml-worker-image-size.md).
+#
+# Nothing in this worker compiles a CUDA extension -- cellpose is pure Python on
+# top of PyTorch -- so the CUDA *devel* image only serves to give the build stage
+# a compiler for any source-only pip dependency. The runtime stage ships on the
+# much smaller CUDA *runtime* image and copies over just the finished conda env,
+# the trees that are pip-installed in editable mode, and the model cache.
+#
+# The previous `FROM base as build` was a no-op: nothing was ever copied between
+# stages, so the toolchain, the miniforge installer, the pip wheel cache and the
+# conda package cache all stayed in the shipped image.
+#
+# PyTorch never uses the base image's CUDA libraries: it loads the cuDNN /
+# cuBLAS / cuFFT / NCCL shipped inside its own `nvidia-*` pip wheels under
+# site-packages. That is why the runtime stage does not need a `cudnn` tag.
+# ---------------------------------------------------------------------------
+FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04 AS build
 
-ENV NVIDIA_VISIBLE_DEVICES all
-ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+# pip's wheel cache is a full second copy of the torch + nvidia-* wheels
+# (~4 GB) and is worthless inside an image.
+ENV PIP_NO_CACHE_DIR=1
 
+# Build-time toolchain only; none of this is carried into the runtime stage.
+# `r-base` (listed twice) and `software-properties-common` were never used.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qy tzdata && \
-  apt-get install -qy software-properties-common python3-software-properties && \
-  apt-get update && apt-get install -qy \
+  apt-get install -qy \
   build-essential \
   wget \
-  python3 \
-  r-base \
+  git \
   libffi-dev \
   libssl-dev \
   libjpeg-dev \
   zlib1g-dev \
-  r-base \
-  git \
   libpython3-dev && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -30,36 +44,76 @@ RUN wget \
     && bash Miniforge3-Linux-x86_64.sh -b \
     && rm -f Miniforge3-Linux-x86_64.sh
 
-FROM base as build
-
 COPY ./workers/annotations/cellposesam/environment.yml /
 RUN conda env create --file /environment.yml
 SHELL ["conda", "run", "-n", "worker", "/bin/bash", "-c"]
 
-RUN git clone https://github.com/arjunrajlaboratory/DeepTile
+# Shallow clones: full history is dead weight in an image. The DeepTile checkout
+# is ~140 MB but the importable package is 160 KB -- the rest is .git, sample
+# `data` (56 MB) and `notebooks` (37 MB). It is installed editable, so the tree
+# has to survive into the runtime stage; prune it here rather than ship it.
+RUN git clone --depth 1 https://github.com/arjunrajlaboratory/DeepTile && \
+    rm -rf /DeepTile/.git /DeepTile/data /DeepTile/notebooks /DeepTile/tests
 RUN pip install -e /DeepTile
 RUN pip install rtree shapely
 
-RUN git clone https://github.com/Kitware/UPennContrast/
+RUN git clone --depth 1 https://github.com/Kitware/UPennContrast/ && rm -rf /UPennContrast/.git
 
 RUN pip install -r /UPennContrast/devops/girder/annotation_client/requirements.txt
 RUN pip install -e /UPennContrast/devops/girder/annotation_client/
 
 # models_config.py is the single source of truth for the built-in checkpoints,
-# so it must be present before download_models.py runs.
+# so it must be present before download_models.py runs. It is also imported by
+# entrypoint.py, so the runtime stage copies it in again.
 COPY ./workers/annotations/cellposesam/models_config.py /
 COPY ./workers/annotations/cellposesam/download_models.py /
 RUN python /download_models.py
-
-COPY ./workers/annotations/cellposesam/utils.py /
-COPY ./workers/annotations/cellposesam/girder_utils.py /
-COPY ./workers/annotations/cellposesam/entrypoint.py /
 
 COPY ./annotation_utilities /annotation_utilities
 RUN pip install /annotation_utilities
 
 COPY ./worker_client /worker_client
 RUN pip install /worker_client
+
+# Drop conda's package cache / tarballs -- another full copy of the env.
+RUN conda clean --all --yes
+
+# ---------------------------------------------------------------------------
+# Runtime stage
+# ---------------------------------------------------------------------------
+FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04
+
+LABEL isUPennContrastWorker=True
+LABEL com.nvidia.volumes.needed="nvidia_driver"
+
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qy \
+  tzdata \
+  ca-certificates && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/root/miniforge3/envs/worker/bin:$PATH"
+
+# The finished conda env, plus every tree that was pip-installed with `-e` and
+# therefore has to stay at its build-time path. Only the annotation_client
+# subtree is needed from the UPennContrast checkout, not the whole repo. Note
+# that `conda` itself is deliberately not copied -- run_worker.sh activates the
+# env by path, so the base conda install is build-time only.
+COPY --from=build /root/miniforge3/envs/worker /root/miniforge3/envs/worker
+COPY --from=build /UPennContrast/devops/girder/annotation_client /UPennContrast/devops/girder/annotation_client
+COPY --from=build /DeepTile /DeepTile
+# cellpose 4.x resolves checkpoints from ~/.cellpose/models (models.MODEL_DIR),
+# which is where download_models.py put cpsam_v2 / cpsam. The worker's own
+# .cellposesam directory holds Girder-synced custom models and is created at
+# runtime.
+COPY --from=build /root/.cellpose /root/.cellpose
+
+COPY ./workers/annotations/cellposesam/models_config.py /
+COPY ./workers/annotations/cellposesam/utils.py /
+COPY ./workers/annotations/cellposesam/girder_utils.py /
+COPY ./workers/annotations/cellposesam/entrypoint.py /
 
 LABEL isUPennContrastWorker=True \
       isGPUWorker="true" \

--- a/workers/annotations/cellposesam_train/Dockerfile
+++ b/workers/annotations/cellposesam_train/Dockerfile
@@ -1,23 +1,37 @@
-FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04 as base
-LABEL isUPennContrastWorker=True
-LABEL com.nvidia.volumes.needed="nvidia_driver"
+# ---------------------------------------------------------------------------
+# Multi-stage build (see todo/ml-worker-image-size.md).
+#
+# Nothing in this worker compiles a CUDA extension -- cellpose is pure Python on
+# top of PyTorch -- so the CUDA *devel* image only serves to give the build stage
+# a compiler for any source-only pip dependency. The runtime stage ships on the
+# much smaller CUDA *runtime* image and copies over just the finished conda env,
+# the trees that are pip-installed in editable mode, and the model cache.
+#
+# The previous `FROM base as build` was a no-op: nothing was ever copied between
+# stages, so the toolchain, the miniforge installer, the pip wheel cache and the
+# conda package cache all stayed in the shipped image.
+#
+# PyTorch never uses the base image's CUDA libraries: it loads the cuDNN /
+# cuBLAS / cuFFT / NCCL shipped inside its own `nvidia-*` pip wheels under
+# site-packages. That is why the runtime stage does not need a `cudnn` tag.
+# ---------------------------------------------------------------------------
+FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04 AS build
 
-ENV NVIDIA_VISIBLE_DEVICES all
-ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+# pip's wheel cache is a full second copy of the torch + nvidia-* wheels
+# (~4 GB) and is worthless inside an image.
+ENV PIP_NO_CACHE_DIR=1
 
+# Build-time toolchain only; none of this is carried into the runtime stage.
+# `r-base` (listed twice) and `software-properties-common` were never used.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qy tzdata && \
-  apt-get install -qy software-properties-common python3-software-properties && \
-  apt-get update && apt-get install -qy \
+  apt-get install -qy \
   build-essential \
   wget \
-  python3 \
-  r-base \
+  git \
   libffi-dev \
   libssl-dev \
   libjpeg-dev \
   zlib1g-dev \
-  r-base \
-  git \
   libpython3-dev && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -30,34 +44,68 @@ RUN wget \
     && bash Miniforge3-Linux-x86_64.sh -b \
     && rm -f Miniforge3-Linux-x86_64.sh
 
-FROM base as build
-
 COPY ./workers/annotations/cellposesam_train/environment.yml /
 RUN conda env create --file /environment.yml
 SHELL ["conda", "run", "-n", "worker", "/bin/bash", "-c"]
 
 RUN pip install rtree shapely
 
-RUN git clone https://github.com/Kitware/UPennContrast/
+# Shallow clone: full history is dead weight in an image.
+RUN git clone --depth 1 https://github.com/Kitware/UPennContrast/ && rm -rf /UPennContrast/.git
 
 RUN pip install -r /UPennContrast/devops/girder/annotation_client/requirements.txt
 RUN pip install -e /UPennContrast/devops/girder/annotation_client/
 
 # models_config.py is the single source of truth for the built-in checkpoints,
-# so it must be present before download_models.py runs.
+# so it must be present before download_models.py runs. It is also imported by
+# entrypoint.py, so the runtime stage copies it in again.
 COPY ./workers/annotations/cellposesam_train/models_config.py /
 COPY ./workers/annotations/cellposesam_train/download_models.py /
 RUN python /download_models.py
-
-COPY ./workers/annotations/cellposesam_train/utils.py /
-COPY ./workers/annotations/cellposesam_train/girder_utils.py /
-COPY ./workers/annotations/cellposesam_train/entrypoint.py /
 
 COPY ./annotation_utilities /annotation_utilities
 RUN pip install /annotation_utilities
 
 COPY ./worker_client /worker_client
 RUN pip install /worker_client
+
+# Drop conda's package cache / tarballs -- another full copy of the env.
+RUN conda clean --all --yes
+
+# ---------------------------------------------------------------------------
+# Runtime stage
+# ---------------------------------------------------------------------------
+FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04
+
+LABEL isUPennContrastWorker=True
+LABEL com.nvidia.volumes.needed="nvidia_driver"
+
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qy \
+  tzdata \
+  ca-certificates && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/root/miniforge3/envs/worker/bin:$PATH"
+
+# The finished conda env, plus every tree that was pip-installed with `-e` and
+# therefore has to stay at its build-time path. Only the annotation_client
+# subtree is needed from the UPennContrast checkout, not the whole repo. Note
+# that `conda` itself is deliberately not copied -- run_worker.sh activates the
+# env by path, so the base conda install is build-time only.
+COPY --from=build /root/miniforge3/envs/worker /root/miniforge3/envs/worker
+COPY --from=build /UPennContrast/devops/girder/annotation_client /UPennContrast/devops/girder/annotation_client
+# cellpose 4.x resolves the base checkpoints from ~/.cellpose/models
+# (models.MODEL_DIR). The fine-tuned models this worker produces go to its own
+# /root/.cellposesam/models, which entrypoint.py creates at runtime.
+COPY --from=build /root/.cellpose /root/.cellpose
+
+COPY ./workers/annotations/cellposesam_train/models_config.py /
+COPY ./workers/annotations/cellposesam_train/utils.py /
+COPY ./workers/annotations/cellposesam_train/girder_utils.py /
+COPY ./workers/annotations/cellposesam_train/entrypoint.py /
 
 LABEL isUPennContrastWorker="" \
       isGPUWorker="true" \

--- a/workers/annotations/condensatenet/Dockerfile
+++ b/workers/annotations/condensatenet/Dockerfile
@@ -1,21 +1,37 @@
-FROM nvidia/cuda:12.1.0-cudnn8-devel-ubuntu22.04 as base
-LABEL isUPennContrastWorker=True
-LABEL com.nvidia.volumes.needed="nvidia_driver"
+# ---------------------------------------------------------------------------
+# Multi-stage build (see todo/ml-worker-image-size.md).
+#
+# Nothing in this worker compiles a CUDA extension -- condensatenet is pure
+# Python on top of PyTorch / transformers -- so the CUDA *devel* image only
+# serves to give the build stage a compiler for any source-only pip dependency.
+# The runtime stage ships on the much smaller CUDA *runtime* image and copies
+# over just the finished conda env, the trees that are pip-installed in editable
+# mode, and the baked-in model snapshots.
+#
+# The previous `FROM base as build` was a no-op: nothing was ever copied between
+# stages, so the toolchain, the miniforge installer, the pip wheel cache and the
+# conda package cache all stayed in the shipped image.
+#
+# PyTorch never uses the base image's CUDA libraries: it loads the cuDNN /
+# cuBLAS / cuFFT / NCCL shipped inside its own `nvidia-*` pip wheels under
+# site-packages. That is why the runtime stage does not need a `cudnn` tag.
+# ---------------------------------------------------------------------------
+FROM nvidia/cuda:12.1.0-cudnn8-devel-ubuntu22.04 AS build
 
-ENV NVIDIA_VISIBLE_DEVICES all
-ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+# pip's wheel cache is a full second copy of the torch + nvidia-* wheels
+# (~4 GB) and is worthless inside an image.
+ENV PIP_NO_CACHE_DIR=1
 
+# Build-time toolchain only; none of this is carried into the runtime stage.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qy tzdata && \
-  apt-get install -qy software-properties-common python3-software-properties && \
-  apt-get update && apt-get install -qy \
+  apt-get install -qy \
   build-essential \
   wget \
-  python3 \
+  git \
   libffi-dev \
   libssl-dev \
   libjpeg-dev \
   zlib1g-dev \
-  git \
   libpython3-dev && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -28,15 +44,14 @@ RUN wget \
     && bash Miniforge3-Linux-x86_64.sh -b \
     && rm -f Miniforge3-Linux-x86_64.sh
 
-FROM base as build
-
 # Copy and create conda environment
 COPY ./workers/annotations/condensatenet/environment.yml /
 RUN conda env create --file /environment.yml
 SHELL ["conda", "run", "-n", "worker", "/bin/bash", "-c"]
 
-# Install NimbusImage annotation client
-RUN git clone https://github.com/arjunrajlaboratory/NimbusImage/
+# Install NimbusImage annotation client. Shallow clone: full history is dead
+# weight in an image.
+RUN git clone --depth 1 https://github.com/arjunrajlaboratory/NimbusImage/ && rm -rf /NimbusImage/.git
 RUN pip install -r /NimbusImage/devops/girder/annotation_client/requirements.txt
 RUN pip install -e /NimbusImage/devops/girder/annotation_client/
 
@@ -45,7 +60,12 @@ COPY ./annotation_utilities /annotation_utilities
 RUN pip install /annotation_utilities
 
 # Install DeepTile for tiling support
-RUN git clone https://github.com/arjunrajlaboratory/DeepTile
+# The DeepTile checkout is ~140 MB but the importable package is 160 KB: the
+# rest is .git, sample `data` (56 MB) and `notebooks` (37 MB). It is installed
+# editable, so the tree has to survive into the runtime stage -- prune it here
+# rather than ship the samples.
+RUN git clone --depth 1 https://github.com/arjunrajlaboratory/DeepTile && \
+    rm -rf /DeepTile/.git /DeepTile/data /DeepTile/notebooks /DeepTile/tests
 RUN pip install -e /DeepTile
 
 # Install worker_client for batch processing
@@ -55,9 +75,43 @@ RUN pip install /worker_client
 # Install CondensateNet package
 RUN pip install git+https://github.com/arjunrajlaboratory/condensatenet.git
 
-# Download CondensateNet models (bake into image for faster startup)
+# Download CondensateNet models (bake into image for faster startup). These are
+# real file copies (snapshot_download local_dir_use_symlinks=False), so /models
+# is self-contained and is all the runtime stage needs.
 RUN python -m condensatenet download --output /models/condensatenet
 RUN python -m condensatenet download --repo-id rajlab/condensatenet-v1 --output /models/condensatenet-v1
+
+# Drop conda's package cache / tarballs -- another full copy of the env.
+RUN conda clean --all --yes
+
+# ---------------------------------------------------------------------------
+# Runtime stage
+# ---------------------------------------------------------------------------
+FROM nvidia/cuda:12.1.0-runtime-ubuntu22.04
+
+LABEL isUPennContrastWorker=True
+LABEL com.nvidia.volumes.needed="nvidia_driver"
+
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qy \
+  tzdata \
+  ca-certificates && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/root/miniforge3/envs/worker/bin:$PATH"
+
+# The finished conda env, plus every tree that was pip-installed with `-e` and
+# therefore has to stay at its build-time path. Only the annotation_client
+# subtree is needed from the NimbusImage checkout, not the whole repo. Note that
+# `conda` itself is deliberately not copied -- run_worker.sh activates the env by
+# path, so the base conda install is build-time only.
+COPY --from=build /root/miniforge3/envs/worker /root/miniforge3/envs/worker
+COPY --from=build /NimbusImage/devops/girder/annotation_client /NimbusImage/devops/girder/annotation_client
+COPY --from=build /DeepTile /DeepTile
+# entrypoint.py hardcodes /models/condensatenet and /models/condensatenet-v1.
+COPY --from=build /models /models
 
 # Copy entrypoint
 COPY ./workers/annotations/condensatenet/entrypoint.py /

--- a/workers/annotations/piscis/PISCIS.md
+++ b/workers/annotations/piscis/PISCIS.md
@@ -60,6 +60,7 @@ In **Z-Stack mode**, all Z slices are passed to the model at once for 3D detecti
 - Training validates that annotation tags, region tags, annotations, and regions are all non-empty before proceeding, sending user-facing error messages via `sendError()` for each failure case.
 - Training uses a warmup fraction of 0.1 (10% of epochs) and splits the random seed into two child seeds -- one for dataset generation and one for model training.
 - Both predict and train automatically use CUDA if a GPU is available, falling back to CPU otherwise.
+- Both images must install `libgl1`, `libglib2.0-0`, `libsm6`, `libice6`, `libx11-6` and `libxext6`. `piscis` depends on `opencv-python` (not `opencv-python-headless`) and imports `cv2` at module scope in `piscis/transforms.py`, so `import piscis` fails without them — at build time as well, since `download_models.py` imports the package. They are listed explicitly in both Dockerfile stages; before the multi-stage rewrite they arrived by accident through `r-base`'s dependency tree. Do not remove them without first switching the worker to `opencv-python-headless`, which needs nothing beyond glibc.
 
 ## Notes
 

--- a/workers/annotations/piscis/predict/Dockerfile
+++ b/workers/annotations/piscis/predict/Dockerfile
@@ -26,8 +26,17 @@ FROM nvidia/cuda:12.4.1-devel-ubuntu22.04 AS build
 # (~4 GB) and is worthless inside an image.
 ENV PIP_NO_CACHE_DIR=1
 
-# Build-time toolchain only; none of this is carried into the runtime stage.
-# `r-base` (listed twice) and `software-properties-common` were never used.
+# Build-time toolchain, plus the opencv runtime libs (see below) -- only the
+# latter are repeated in the runtime stage.
+#
+# `r-base` (listed twice) and `software-properties-common` were never used
+# *directly*, but r-base-core's dependency tree was silently supplying the
+# shared libraries `opencv-python` needs: libglib2.0-0, libx11-6, libsm6 and
+# libice6 (via libxt6) and libxext6 (via libtk8.6). piscis depends on
+# `opencv-python` -- not `-headless` -- and imports cv2 at module scope in
+# piscis/transforms.py, so `import piscis` needs them here as well: the
+# `python /download_models.py` step below imports the package. libgl1 is listed
+# explicitly rather than left to whatever the CUDA base happens to carry.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qy tzdata && \
   apt-get install -qy \
   build-essential \
@@ -37,7 +46,13 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qy tzdata 
   libssl-dev \
   libjpeg-dev \
   zlib1g-dev \
-  libpython3-dev && \
+  libpython3-dev \
+  libgl1 \
+  libglib2.0-0 \
+  libsm6 \
+  libice6 \
+  libx11-6 \
+  libxext6 && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/root/miniforge3/bin:$PATH"
@@ -90,9 +105,17 @@ LABEL com.nvidia.volumes.needed="nvidia_driver"
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 
+# libgl1 .. libxext6 are what `opencv-python` links against; piscis imports cv2
+# at module scope, so the worker cannot start without them. See the build stage.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qy \
   tzdata \
-  ca-certificates && \
+  ca-certificates \
+  libgl1 \
+  libglib2.0-0 \
+  libsm6 \
+  libice6 \
+  libx11-6 \
+  libxext6 && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/root/miniforge3/envs/worker/bin:$PATH"

--- a/workers/annotations/piscis/predict/Dockerfile
+++ b/workers/annotations/piscis/predict/Dockerfile
@@ -1,49 +1,60 @@
-FROM nvidia/cuda:12.4.1-devel-ubuntu22.04 as base
-LABEL com.nvidia.volumes.needed="nvidia_driver"
+# ---------------------------------------------------------------------------
+# Multi-stage build (see todo/ml-worker-image-size.md).
+#
+# Nothing in this worker compiles a CUDA extension -- piscis 1.x is pure Python
+# on top of PyTorch -- so the CUDA *devel* image only serves to give the build
+# stage a compiler for any source-only pip dependency. The runtime stage ships on
+# the much smaller CUDA *runtime* image and copies over just the finished conda
+# env, the trees that are pip-installed in editable mode, and the model cache.
+#
+# The previous `FROM base as build` was a no-op: nothing was ever copied between
+# stages, so the toolchain, the conda installer, the pip wheel cache and the
+# conda package cache all stayed in the shipped image.
+#
+# PyTorch never uses the base image's CUDA libraries: it loads the cuDNN /
+# cuBLAS / cuFFT / NCCL shipped inside its own `nvidia-*` pip wheels under
+# site-packages.
+#
+# Miniconda was also swapped for Miniforge here, matching every other worker.
+# That drops the `defaults` channel and with it the `conda tos accept` dance;
+# this worker's environment.yml is only `python=3.11` + `pip`, all of which
+# conda-forge provides.
+# ---------------------------------------------------------------------------
+FROM nvidia/cuda:12.4.1-devel-ubuntu22.04 AS build
 
-ENV NVIDIA_VISIBLE_DEVICES all
-ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+# pip's wheel cache is a full second copy of the torch + nvidia-* wheels
+# (~4 GB) and is worthless inside an image.
+ENV PIP_NO_CACHE_DIR=1
 
-LABEL isUPennContrastWorker=True
-LABEL isAnnotationWorker=True
-LABEL interfaceName="Piscis (Predict)"
-LABEL interfaceCategory="Piscis"
-
+# Build-time toolchain only; none of this is carried into the runtime stage.
+# `r-base` (listed twice) and `software-properties-common` were never used.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qy tzdata && \
-  apt-get install -qy software-properties-common python3-software-properties && \
-  apt-get update && apt-get install -qy \
+  apt-get install -qy \
   build-essential \
   wget \
-  python3 \
-  r-base \
+  git \
   libffi-dev \
   libssl-dev \
   libjpeg-dev \
   zlib1g-dev \
-  r-base \
-  git \
   libpython3-dev && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
-ENV PATH="/root/miniconda3/bin:$PATH"
-ARG PATH="/root/miniconda3/bin:$PATH"
+ENV PATH="/root/miniforge3/bin:$PATH"
+ARG PATH="/root/miniforge3/bin:$PATH"
 
 RUN wget \
-    https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+    https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh \
     && mkdir /root/.conda \
-    && bash Miniconda3-latest-Linux-x86_64.sh -b \
-    && rm -f Miniconda3-latest-Linux-x86_64.sh
-
-FROM base as build
-
-RUN conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main && \
-    conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
+    && bash Miniforge3-Linux-x86_64.sh -b \
+    && rm -f Miniforge3-Linux-x86_64.sh
 
 COPY ./workers/annotations/piscis/environment.yml /
 RUN conda env create --file /environment.yml
 SHELL ["conda", "run", "-n", "worker", "/bin/bash", "-c"]
 
-RUN git clone https://github.com/Kitware/UPennContrast/
+# Shallow clone: full history is dead weight in an image.
+RUN git clone --depth 1 https://github.com/Kitware/UPennContrast/ && rm -rf /UPennContrast/.git
 
 RUN pip install -r /UPennContrast/devops/girder/annotation_client/requirements.txt
 RUN pip install -e /UPennContrast/devops/girder/annotation_client/
@@ -51,12 +62,51 @@ RUN pip install -e /UPennContrast/devops/girder/annotation_client/
 RUN pip install piscis==1.0.0
 
 WORKDIR /
-RUN git clone https://github.com/arjunrajlaboratory/ImageAnalysisProject/
-RUN pip install /ImageAnalysisProject/annotation_utilities
-RUN pip install /ImageAnalysisProject/worker_client
+# Install the local annotation_utilities / worker_client, not a fresh clone of
+# ImageAnalysisProject from GitHub: cloning built the image against whatever was
+# on the default branch instead of the tree being built.
+COPY ./annotation_utilities /annotation_utilities
+RUN pip install /annotation_utilities
 
+COPY ./worker_client /worker_client
+RUN pip install /worker_client
+
+# Bakes the pretrained models into ~/.piscis/models so the first run does not
+# have to download them. That directory is copied into the runtime stage.
 COPY ./workers/annotations/piscis/download_models.py /
 RUN python /download_models.py
+
+# Drop conda's package cache / tarballs -- another full copy of the env.
+RUN conda clean --all --yes
+
+# ---------------------------------------------------------------------------
+# Runtime stage
+# ---------------------------------------------------------------------------
+FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04
+
+LABEL isUPennContrastWorker=True
+LABEL com.nvidia.volumes.needed="nvidia_driver"
+
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qy \
+  tzdata \
+  ca-certificates && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/root/miniforge3/envs/worker/bin:$PATH"
+
+# The finished conda env, plus every tree that was pip-installed with `-e` and
+# therefore has to stay at its build-time path. Only the annotation_client
+# subtree is needed from the UPennContrast checkout, not the whole repo. Note
+# that `conda` itself is deliberately not copied -- run_worker.sh activates the
+# env by path, so the base conda install is build-time only.
+COPY --from=build /root/miniforge3/envs/worker /root/miniforge3/envs/worker
+COPY --from=build /UPennContrast/devops/girder/annotation_client /UPennContrast/devops/girder/annotation_client
+# piscis.paths.MODELS_DIR is ~/.piscis/models; utils.download_girder_model also
+# writes user models there at runtime.
+COPY --from=build /root/.piscis /root/.piscis
 
 COPY ./workers/annotations/piscis/utils.py /
 COPY ./workers/annotations/piscis/predict/entrypoint.py /

--- a/workers/annotations/piscis/train/Dockerfile
+++ b/workers/annotations/piscis/train/Dockerfile
@@ -1,67 +1,117 @@
-FROM nvidia/cuda:12.4.1-devel-ubuntu22.04 as base
-LABEL com.nvidia.volumes.needed="nvidia_driver"
+# ---------------------------------------------------------------------------
+# Multi-stage build (see todo/ml-worker-image-size.md).
+#
+# Nothing in this worker compiles a CUDA extension -- piscis is pure Python on
+# top of PyTorch -- so the CUDA *devel* image only serves to give the build stage
+# a compiler for any source-only pip dependency. The runtime stage ships on the
+# much smaller CUDA *runtime* image and copies over just the finished conda env,
+# the trees that are pip-installed in editable mode, and the model cache.
+#
+# The previous `FROM base as build` was a no-op: nothing was ever copied between
+# stages, so the toolchain, the conda installer, the pip wheel cache and the
+# conda package cache all stayed in the shipped image.
+#
+# PyTorch never uses the base image's CUDA libraries: it loads the cuDNN /
+# cuBLAS / cuFFT / NCCL shipped inside its own `nvidia-*` pip wheels under
+# site-packages.
+#
+# Miniconda was also swapped for Miniforge here, matching every other worker.
+# That drops the `defaults` channel and with it the `conda tos accept` dance;
+# this worker's environment.yml is only `python=3.11` + `pip`, all of which
+# conda-forge provides.
+# ---------------------------------------------------------------------------
+FROM nvidia/cuda:12.4.1-devel-ubuntu22.04 AS build
 
-ENV NVIDIA_VISIBLE_DEVICES all
-ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+# pip's wheel cache is a full second copy of the torch + nvidia-* wheels
+# (~4 GB) and is worthless inside an image.
+ENV PIP_NO_CACHE_DIR=1
 
-LABEL isUPennContrastWorker=True
-LABEL isAnnotationWorker=True
-LABEL interfaceName="Piscis (Train)"
-LABEL interfaceCategory="Piscis"
-
+# Build-time toolchain only; none of this is carried into the runtime stage.
+# `r-base` (listed twice) and `software-properties-common` were never used.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qy tzdata && \
-  apt-get install -qy software-properties-common python3-software-properties && \
-  apt-get update && apt-get install -qy \
+  apt-get install -qy \
   build-essential \
   wget \
-  python3 \
-  r-base \
+  git \
   libffi-dev \
   libssl-dev \
   libjpeg-dev \
   zlib1g-dev \
-  r-base \
-  git \
   libpython3-dev && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
-ENV PATH="/root/miniconda3/bin:$PATH"
-ARG PATH="/root/miniconda3/bin:$PATH"
+ENV PATH="/root/miniforge3/bin:$PATH"
+ARG PATH="/root/miniforge3/bin:$PATH"
 
 RUN wget \
-    https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+    https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh \
     && mkdir /root/.conda \
-    && bash Miniconda3-latest-Linux-x86_64.sh -b \
-    && rm -f Miniconda3-latest-Linux-x86_64.sh
-
-FROM base as build
-
-RUN conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main && \
-    conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
+    && bash Miniforge3-Linux-x86_64.sh -b \
+    && rm -f Miniforge3-Linux-x86_64.sh
 
 COPY ./workers/annotations/piscis/environment.yml /
 RUN conda env create --file /environment.yml
 SHELL ["conda", "run", "-n", "worker", "/bin/bash", "-c"]
 
-RUN git clone https://github.com/arjunrajlaboratory/NimbusImage
+# Shallow clones: full history is dead weight in an image.
+RUN git clone --depth 1 https://github.com/arjunrajlaboratory/NimbusImage && rm -rf /NimbusImage/.git
 
 RUN pip install -r /NimbusImage/devops/girder/annotation_client/requirements.txt
 RUN pip install -e /NimbusImage/devops/girder/annotation_client/
 
-
-RUN git clone https://github.com/zjniu/Piscis.git
+# Installed non-editable, so the clone itself is build-stage only.
+RUN git clone --depth 1 https://github.com/zjniu/Piscis.git && rm -rf /Piscis/.git
 WORKDIR /Piscis
 RUN pip install .
 
 WORKDIR /
 RUN pip install rasterio shapely
 
-RUN git clone https://github.com/arjunrajlaboratory/ImageAnalysisProject/
-RUN pip install /ImageAnalysisProject/annotation_utilities
-RUN pip install /ImageAnalysisProject/worker_client
+# Install the local annotation_utilities / worker_client, not a fresh clone of
+# ImageAnalysisProject from GitHub: cloning built the image against whatever was
+# on the default branch instead of the tree being built.
+COPY ./annotation_utilities /annotation_utilities
+RUN pip install /annotation_utilities
 
+COPY ./worker_client /worker_client
+RUN pip install /worker_client
+
+# Bakes the pretrained models into ~/.piscis/models so the first run does not
+# have to download them. That directory is copied into the runtime stage.
 COPY ./workers/annotations/piscis/download_models.py /
 RUN python /download_models.py
+
+# Drop conda's package cache / tarballs -- another full copy of the env.
+RUN conda clean --all --yes
+
+# ---------------------------------------------------------------------------
+# Runtime stage
+# ---------------------------------------------------------------------------
+FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04
+
+LABEL isUPennContrastWorker=True
+LABEL com.nvidia.volumes.needed="nvidia_driver"
+
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qy \
+  tzdata \
+  ca-certificates && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/root/miniforge3/envs/worker/bin:$PATH"
+
+# The finished conda env, plus every tree that was pip-installed with `-e` and
+# therefore has to stay at its build-time path. Only the annotation_client
+# subtree is needed from the NimbusImage checkout, not the whole repo. Note that
+# `conda` itself is deliberately not copied -- run_worker.sh activates the env by
+# path, so the base conda install is build-time only.
+COPY --from=build /root/miniforge3/envs/worker /root/miniforge3/envs/worker
+COPY --from=build /NimbusImage/devops/girder/annotation_client /NimbusImage/devops/girder/annotation_client
+# piscis.paths.MODELS_DIR is ~/.piscis/models; this worker also writes the models
+# it trains there before uploading them to Girder.
+COPY --from=build /root/.piscis /root/.piscis
 
 COPY ./workers/annotations/piscis/utils.py /
 COPY ./workers/annotations/piscis/train/entrypoint.py /

--- a/workers/annotations/piscis/train/Dockerfile
+++ b/workers/annotations/piscis/train/Dockerfile
@@ -26,8 +26,17 @@ FROM nvidia/cuda:12.4.1-devel-ubuntu22.04 AS build
 # (~4 GB) and is worthless inside an image.
 ENV PIP_NO_CACHE_DIR=1
 
-# Build-time toolchain only; none of this is carried into the runtime stage.
-# `r-base` (listed twice) and `software-properties-common` were never used.
+# Build-time toolchain, plus the opencv runtime libs (see below) -- only the
+# latter are repeated in the runtime stage.
+#
+# `r-base` (listed twice) and `software-properties-common` were never used
+# *directly*, but r-base-core's dependency tree was silently supplying the
+# shared libraries `opencv-python` needs: libglib2.0-0, libx11-6, libsm6 and
+# libice6 (via libxt6) and libxext6 (via libtk8.6). piscis depends on
+# `opencv-python` -- not `-headless` -- and imports cv2 at module scope in
+# piscis/transforms.py, so `import piscis` needs them here as well: the
+# `python /download_models.py` step below imports the package. libgl1 is listed
+# explicitly rather than left to whatever the CUDA base happens to carry.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qy tzdata && \
   apt-get install -qy \
   build-essential \
@@ -37,7 +46,13 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qy tzdata 
   libssl-dev \
   libjpeg-dev \
   zlib1g-dev \
-  libpython3-dev && \
+  libpython3-dev \
+  libgl1 \
+  libglib2.0-0 \
+  libsm6 \
+  libice6 \
+  libx11-6 \
+  libxext6 && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/root/miniforge3/bin:$PATH"
@@ -95,9 +110,17 @@ LABEL com.nvidia.volumes.needed="nvidia_driver"
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 
+# libgl1 .. libxext6 are what `opencv-python` links against; piscis imports cv2
+# at module scope, so the worker cannot start without them. See the build stage.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qy \
   tzdata \
-  ca-certificates && \
+  ca-certificates \
+  libgl1 \
+  libglib2.0-0 \
+  libsm6 \
+  libice6 \
+  libx11-6 \
+  libxext6 && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/root/miniforge3/envs/worker/bin:$PATH"

--- a/workers/annotations/stardist/Dockerfile
+++ b/workers/annotations/stardist/Dockerfile
@@ -81,6 +81,15 @@ RUN conda clean --all --yes
 
 # ---------------------------------------------------------------------------
 # Runtime stage
+#
+# The runtime image has no /usr/local/cuda/bin, so `ptxas` is gone. TF wants it
+# to JIT PTX and to run the redzone-checked conv autotune, and logs on every run:
+#   Couldn't invoke ptxas --version / Relying on driver to perform ptx compilation
+# That fallback is correct -- verified against a real segmentation with cuDNN
+# 8906 loaded on the GPU -- so this is accepted rather than fixed; adding
+# `cuda-nvcc` back would cost a few hundred MB to silence log noise. See
+# todo/ml-worker-image-size.md. (The torch workers never hit this: the triton
+# wheel bundles its own ptxas.)
 # ---------------------------------------------------------------------------
 FROM nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
 

--- a/workers/annotations/stardist/Dockerfile
+++ b/workers/annotations/stardist/Dockerfile
@@ -1,23 +1,40 @@
-FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04 as base
-LABEL isUPennContrastWorker=True
-LABEL com.nvidia.volumes.needed="nvidia_driver"
+# ---------------------------------------------------------------------------
+# Multi-stage build (see todo/ml-worker-image-size.md).
+#
+# Nothing in this worker compiles a CUDA extension -- stardist ships manylinux
+# wheels -- so the CUDA *devel* image only serves to give the build stage a
+# compiler for any source-only pip dependency. The runtime stage ships on the
+# CUDA *runtime* image and copies over just the finished conda env, the trees
+# that are pip-installed in editable mode, and the model cache.
+#
+# The previous `FROM base as build` was a no-op: nothing was ever copied between
+# stages, so the toolchain, the miniforge installer, the pip wheel cache and the
+# conda package cache all stayed in the shipped image.
+#
+# NOTE the `cudnn8` tag on the runtime stage, which the torch-based workers do
+# not need. TensorFlow 2.11 predates the `tensorflow[and-cuda]` extra (2.14), so
+# its PyPI wheel declares no `nvidia-*` dependencies and dlopens libcudnn.so.8 /
+# libcublas / libcufft from the *image*. Dropping to a plain `-runtime` tag would
+# silently lose the GPU (TF logs "Could not load dynamic library libcudnn.so.8"
+# and falls back to CPU) rather than fail the build.
+# ---------------------------------------------------------------------------
+FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04 AS build
 
-ENV NVIDIA_VISIBLE_DEVICES all
-ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+# pip's wheel cache is a full second copy of the tensorflow wheel and is
+# worthless inside an image.
+ENV PIP_NO_CACHE_DIR=1
 
+# Build-time toolchain only; none of this is carried into the runtime stage.
+# `r-base` (listed twice) and `software-properties-common` were never used.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qy tzdata && \
-  apt-get install -qy software-properties-common python3-software-properties && \
-  apt-get update && apt-get install -qy \
+  apt-get install -qy \
   build-essential \
   wget \
-  python3 \
-  r-base \
+  git \
   libffi-dev \
   libssl-dev \
   libjpeg-dev \
   zlib1g-dev \
-  r-base \
-  git \
   libpython3-dev && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -30,32 +47,71 @@ RUN wget \
     && bash Miniforge3-Linux-x86_64.sh -b \
     && rm -f Miniforge3-Linux-x86_64.sh
 
-FROM base as build
-
 COPY ./workers/annotations/stardist/environment.yml /
 RUN conda env create --file /environment.yml
 SHELL ["conda", "run", "-n", "worker", "/bin/bash", "-c"]
 
-RUN git clone https://github.com/arjunrajlaboratory/DeepTile
+# Shallow clones: full history is dead weight in an image. The DeepTile checkout
+# is ~140 MB but the importable package is 160 KB -- the rest is .git, sample
+# `data` (56 MB) and `notebooks` (37 MB). It is installed editable, so the tree
+# has to survive into the runtime stage; prune it here rather than ship it.
+RUN git clone --depth 1 https://github.com/arjunrajlaboratory/DeepTile && \
+    rm -rf /DeepTile/.git /DeepTile/data /DeepTile/notebooks /DeepTile/tests
 RUN pip install -e /DeepTile
 RUN pip install rtree shapely
 
-RUN git clone https://github.com/Kitware/UPennContrast/
+RUN git clone --depth 1 https://github.com/Kitware/UPennContrast/ && rm -rf /UPennContrast/.git
 
 RUN pip install -r /UPennContrast/devops/girder/annotation_client/requirements.txt
 RUN pip install -e /UPennContrast/devops/girder/annotation_client/
 
+# Bakes the pretrained models into the keras cache so the first run does not
+# have to download them. That directory is copied into the runtime stage.
 COPY ./workers/annotations/stardist/download_models.py /
 RUN python /download_models.py
-
-COPY ./workers/annotations/stardist/utils.py /
-COPY ./workers/annotations/stardist/entrypoint.py /
 
 COPY ./annotation_utilities /annotation_utilities
 RUN pip install /annotation_utilities
 
 COPY ./worker_client /worker_client
 RUN pip install /worker_client
+
+# Drop conda's package cache / tarballs -- another full copy of the env.
+RUN conda clean --all --yes
+
+# ---------------------------------------------------------------------------
+# Runtime stage
+# ---------------------------------------------------------------------------
+FROM nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
+
+LABEL isUPennContrastWorker=True
+LABEL com.nvidia.volumes.needed="nvidia_driver"
+
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qy \
+  tzdata \
+  ca-certificates && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/root/miniforge3/envs/worker/bin:$PATH"
+
+# The finished conda env, plus every tree that was pip-installed with `-e` and
+# therefore has to stay at its build-time path. Only the annotation_client
+# subtree is needed from the UPennContrast checkout, not the whole repo. Note
+# that `conda` itself is deliberately not copied -- run_worker.sh activates the
+# env by path, so the base conda install is build-time only.
+COPY --from=build /root/miniforge3/envs/worker /root/miniforge3/envs/worker
+COPY --from=build /UPennContrast/devops/girder/annotation_client /UPennContrast/devops/girder/annotation_client
+COPY --from=build /DeepTile /DeepTile
+# csbdeep's from_pretrained() goes through keras.utils.get_file, which caches
+# under ~/.keras/models -- that is where download_models.py left the two
+# pretrained StarDist2D models.
+COPY --from=build /root/.keras /root/.keras
+
+COPY ./workers/annotations/stardist/utils.py /
+COPY ./workers/annotations/stardist/entrypoint.py /
 
 LABEL isUPennContrastWorker=True \
       isGPUWorker="true" \

--- a/workers/annotations/stardist/STARDIST.md
+++ b/workers/annotations/stardist/STARDIST.md
@@ -24,7 +24,7 @@ This worker uses [StarDist](https://github.com/stardist/stardist) to segment nuc
 
 ## Implementation Details
 
-- **GPU Support**: Built on NVIDIA CUDA 11.8 base image. StarDist uses TensorFlow for GPU-accelerated inference.
+- **GPU Support**: Built on NVIDIA CUDA 11.8 base image. StarDist uses TensorFlow for GPU-accelerated inference. The runtime stage must keep a `cudnn8` tag: TensorFlow 2.11 predates the `tensorflow[and-cuda]` extra (2.14), so its wheel bundles no `nvidia-*` packages and dlopens `libcudnn.so.8` from the image itself. Dropping to a plain `-runtime` tag would not fail the build — TF would log "Could not load dynamic library libcudnn.so.8" and silently fall back to CPU. (The torch-based ML workers are the opposite: their wheels ship their own cuDNN, so they use the plain `-runtime` tag.)
 - **Model Pre-download**: Both pretrained models (`2D_versatile_fluo` and `2D_versatile_he`) are downloaded and cached during Docker build via `download_models.py`, so no network access is needed at runtime.
 - **Polygon Conversion**: Uses `rasterio.features.shapes()` with a transform that maps pixel coordinates directly to image space. Falls back to default transform if the explicit one fails.
 - **No Tiling**: The worker processes the entire image in a single pass (no tile-based processing). Very large images may require significant GPU memory.


### PR DESCRIPTION
Applies the pattern from #160 (SAM/SAM2) to the eight other images built by `build_machine_learning_workers.sh`: `cellpose`, `cellpose_train`, `cellposesam`, `cellposesam_train`, `stardist`, `condensatenet`, `piscis/predict`, `piscis/train`.

> [!NOTE]
> **Built, measured and exercised on x86_64 + RTX 3060 against a live NimbusImage stack.** The size table below is measured, not estimated. One checklist item — an actual retrain — remains unverified; see [Verification](#verification).

## The problem

All eight carried the exact lineage #160 diagnosed:

- a `*-devel` CUDA base whose CUDA stack is shipped **twice** (PyTorch loads the cuDNN/cuBLAS/cuFFT/NCCL inside its own `nvidia-*` pip wheels, never the image's copy)
- a no-op `FROM base as build` — nothing was ever copied between stages, so the whole build environment shipped
- no `PIP_NO_CACHE_DIR` (a full second copy of the wheels) and no `conda clean` (a second copy of the env)
- full-history git clones
- a copy-pasted apt block installing `r-base` **twice**, plus `software-properties-common` and `python3` — none of which any of these workers use

## What changed

Per worker: a real two-stage build (devel base for the build stage, `*-runtime` for the final stage, copying only the finished conda env, the editable-install trees and the baked-in model cache), `ENV PIP_NO_CACHE_DIR=1`, `conda clean --all --yes`, shallow clones, and the dead apt packages dropped. Worker `.py` files now land in the final stage, so editing one no longer invalidates the `annotation_utilities` / `worker_client` installs.

Model caches are carried across the stage boundary so first-run downloads are still avoided — `/root/.cellpose` (both cellpose 3.x and 4.x resolve from `~/.cellpose/models`), `/root/.keras` (csbdeep's `from_pretrained` → `keras.utils.get_file`), `/models` (condensatenet — real files, `snapshot_download` uses `local_dir_use_symlinks=False`) and `/root/.piscis`.

**No `environment.yml` was touched.** Unlike the SAM workers, none of these had a dependency that was provably unused.

### stardist is the exception on the cuDNN tag

Its runtime stage keeps `cudnn8`; the other seven drop it. TensorFlow 2.11 predates the `tensorflow[and-cuda]` extra (2.14), so its wheel declares no `nvidia-*` dependencies and **dlopens** `libcudnn.so.8` from the image. A plain `-runtime` tag would not fail the build — TF logs `Could not load dynamic library libcudnn.so.8` and silently falls back to CPU.

Confirmed against the built images: `pip list` shows `nvidia-cudnn-cu12`/`cu13` wheels in all seven torch workers and **none** in stardist.

### Two piscis bugs fixed along the way

- Both images ran `git clone https://github.com/arjunrajlaboratory/ImageAnalysisProject/` and installed `annotation_utilities` / `worker_client` **from that clone**, so the build used whatever was on the default branch rather than the tree being built — the same bug #160 fixed in `sam_automatic_mask_generator`. They now `COPY` the local directories.
- Miniconda → Miniforge, matching every other worker. Drops the `defaults` channel and both `conda tos accept` calls; `piscis/environment.yml` is only `python=3.11` + `pip`.

### The r-base trap (second commit)

Dropping `r-base` is not purely cosmetic. `r-base-core` *depends on* `libglib2.0-0`, `libx11-6`, `libxt6` (→ `libsm6`, `libice6`), `libtk8.6` (→ `libxext6`) and `libcairo2` (→ `libxcb1`), so every worker carrying it had been getting those shared libraries by accident.

That breaks exactly one worker: `piscis` depends on `opencv-python`, **not** `-headless`, and `piscis/transforms.py` does `import cv2 as cv` at module scope. Without those libs `import piscis` raises `ImportError` — in the **build** stage too, since `download_models.py` imports the package. Both piscis stages now install `libgl1 libglib2.0-0 libsm6 libice6 libx11-6 libxext6` explicitly.

The rest of the fleet was cleared by reading `DT_NEEDED` off every wheel's `.so` files against what each wheel vendors:

| Wheel | Needs from the image |
|---|---|
| `opencv-python` (piscis) | libGL, libglib/libgthread, libX11, libSM, libICE, libXext, libxcb |
| `opencv-python-headless` (cellpose ×4) | nothing beyond glibc/libstdc++ |
| `torch` | nothing — vendors its own libgomp and the whole CUDA stack |
| `tensorflow==2.11.0` (stardist) | nothing linked; dlopens libcudnn.so.8 by name |
| `stardist==0.9.1`, `rtree`, `shapely` | nothing beyond glibc/libstdc++ |

### `ptxas` / `nvcc` are gone from the runtime stage (third commit)

The `*-runtime` images have no `/usr/local/cuda/bin`, so the toolkit binaries disappear. Visible in one place: **stardist** logs `Couldn't invoke ptxas --version` / `Relying on driver to perform ptx compilation` on every run. The fallback is correct — a real segmentation returned the right object count with cuDNN 8906 loaded on the GPU — so this is accepted rather than fixed; adding `cuda-nvcc` back would cost a few hundred MB to silence log noise.

The seven torch workers are unaffected, and not because they never JIT: the `triton` wheel bundles its own `ptxas` under `site-packages/triton/backends/nvidia/bin/`. Documented in `todo/ml-worker-image-size.md` and inline in the stardist Dockerfile.

## Measured impact

Shipped image size, unpacked, from `docker image inspect .Size` (base-10).

| Worker | Before | After | Saved |
|---|---:|---:|---:|
| cellpose | 25.23 G | 8.87 G | −16.36 G (65%) |
| cellpose_train | 25.07 G | 8.88 G | −16.20 G (65%) |
| cellposesam | 23.21 G | 11.21 G | −12.00 G (52%) |
| cellposesam_train | 23.05 G | 11.22 G | −11.83 G (51%) |
| stardist | 20.44 G | 6.69 G | −13.74 G (67%) |
| condensatenet | 24.09 G | 8.28 G | −15.81 G (66%) |
| piscis/predict | 18.53 G | 8.71 G | −9.82 G (53%) |
| piscis/train | 18.87 G | 8.82 G | −10.05 G (53%) |
| **Fleet** | **178.5 G** | **72.7 G** | **−105.8 G (59%)** |

An earlier revision of this description estimated a 215 G → 96 G fleet (−55%). That was written without a Docker daemon and **overstated the baseline**: the real saving is smaller in absolute terms (−105.8 G, not −119 G) but a larger fraction (59%, not 55%).

Build times were 136–293 s per worker. **Compressed pull sizes were not measured** — every figure above is unpacked. The earlier claim that cold build time is "roughly a wash" is unverified and withdrawn: the pre-change images were not rebuilt, so there is no before-time to compare against.

## Verification

1. **Model caches survived the stage copy** — `/root/.cellpose/models` (`cyto*`/`nuclei*` for cellpose 3, `cpsam`+`cpsam_v2` for cellpose 4), `/root/.keras/models/StarDist2D`, `/models/condensatenet-v1`, `/root/.piscis/models` (four dated models + the `rajlab` collection). No first-run download.
2. **GPU genuinely used from the runtime base** — `torch.cuda.is_available()` true for the seven torch workers; stardist reports `[PhysicalDevice('/physical_device:GPU:0')]` with `Loaded cuDNN version 8906` and **no** `Could not load dynamic library libcudnn` line.
3. **`import cv2` succeeds** in both piscis images — the check that would have caught the r-base trap.
4. **Real jobs against a live NimbusImage stack**, all writing annotations back to Girder: cellposesam (17 objects), stardist (17), cellpose (12), condensatenet (7976 condensates), piscis predict (spots). cellposesam was additionally run **through the NimbusImage UI**, whose job log shows `runtime: nvidia` — so the `isGPUWorker` label still routes to the GPU queue through girder_worker.
5. **Training workers** — GPU visible, checkpoints present, the copied model directory is **writable**, and `from cellpose import train` imports.

### Not verified

**An actual retrain.** Item 5 covers the preconditions but no training run was executed, so nothing has yet written a real checkpoint into a directory that arrives via `COPY --from`. This is the weakest point in the verification.

## Out of scope

`deconwolf` is the last GPU worker on this lineage. It is an image-processing worker rather than an ML one and the only one compiling a native binary, so it needs its own pass — `todo/ml-worker-image-size.md` records what that involves, including using `ldd /usr/bin/dw` to enumerate its runtime libs rather than assuming the base image carries them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGVianXJET5VVja76jahvj)_
