### PR TITLE
chore(docker): add a .dockerignore to keep the build context small

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Keep the build context small. Every `docker build` sends the whole context to
+# the daemon before running a single instruction, and every worker here builds
+# from the repo root (`docker build .`), so anything large sitting anywhere in
+# the tree is paid for by all 107 Dockerfiles.
+#
+# Nothing listed below is referenced by any COPY/ADD in the repo -- verified by
+# grepping every Dockerfile. Worker COPY lines name specific files
+# (entrypoint.py, environment.yml, ...) rather than whole directories, and the
+# directories that are copied wholesale (annotation_utilities, worker_client)
+# only lose their stale __pycache__.
+
+.git
+.github
+
+# Local development scratch: per-worker virtualenvs and downloaded model
+# checkpoints. These are gitignored, never copied into an image, and are by far
+# the biggest thing in the context -- on a working checkout they can add ~11 GB
+# (e.g. a 2.6 GB sam_vit_h checkpoint plus several torch/CUDA venvs).
+**/local_tests
+**/.venv
+
+# Compiled bytecode: stale, platform-specific, and regenerated inside the image.
+**/__pycache__
+**/*.py[cod]


### PR DESCRIPTION
Every worker in this repo builds from the repo root (`docker build . -f workers/annotations/<name>/Dockerfile`), and Docker sends the **entire** build context to the daemon before running a single instruction. There was no `.dockerignore`, so that context is the whole working tree.

On a real development checkout that is **~11 GB**, essentially all of it from files no image ever uses:

| Path | Size | What it is |
|---|---:|---|
| `workers/annotations/sam_automatic_mask_generator/local_tests` | 6.5 G | `.venv` with torch/CUDA + a 2.6 GB `sam_vit_h_4b8939.pth` checkpoint |
| `workers/annotations/sam2_fewshot_segmentation/local_tests` | 4.1 G | same shape |
| `.git` | 96 M | |

That cost is paid on every build, by all 107 Dockerfiles in the repo.

## What this excludes

`.git`, `.github`, per-worker `local_tests/` and `.venv/` scratch, and compiled bytecode (`__pycache__`, `*.py[cod]`).

## Why it is safe

Nothing listed is referenced by any `COPY`/`ADD` — checked by grepping every Dockerfile in the repo:

- No `COPY`/`ADD` anywhere mentions `local_tests`, `.venv`, `__pycache__` or `.git`.
- Worker `COPY` lines name **specific files** (`entrypoint.py`, `environment.yml`, `utils.py`, …), not whole worker directories, so excluding a subdirectory of a worker cannot remove anything a build needs.
- The two directories that *are* copied wholesale — `annotation_utilities` and `worker_client` — only lose stale `__pycache__`, which is regenerated inside the image anyway.
- `tests/` is deliberately **not** excluded: the `*_test` images copy it.

Verified in practice as well as by inspection: the eight ML worker images in #163 were all built with this file in place, and each one loaded its baked-in model cache and ran a real job against a live NimbusImage stack.

## Note

This is orthogonal to #163 (image *size*) — this is build *context* transfer, which affects every build in the repo including CPU workers. Split out deliberately so #163 stays focused.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGVianXJET5VVja76jahvj)_
