### PR TITLE
Validate WorkerClient batch coordinates before image access

### DIFF
--- a/todo/TODO_REGISTRY.md
+++ b/todo/TODO_REGISTRY.md
@@ -16,6 +16,7 @@ Master index of deferred work, technical debt, and future improvements for the I
 | TODO-002 | Worker startup latency audit & slimming plan (drop `conda run`) | In progress (#1–#3 done & verified; GPU workers static-validated, need build-host validation) | High | [worker-startup-latency.md](worker-startup-latency.md) | — |
 | TODO-003 | ML worker image size (multi-stage builds across the GPU fleet) | In progress (wave 1 SAM/SAM2 merged; wave 2 cellpose ×4 / stardist / condensatenet / piscis ×2 rewritten but **not yet built or measured**; `deconwolf` still to do) | Medium | [ml-worker-image-size.md](ml-worker-image-size.md) | [#160](https://github.com/arjunrajlaboratory/ImageAnalysisProject/pull/160) |
 | TODO-004 | `channelCheckboxes` list-shaped values: identify the submitter, repair saved configs | Open (workers hardened and now reject the shape; front end surveyed, submitter unidentified) | Medium | [channelcheckboxes-serialization.md](channelcheckboxes-serialization.md) | [#162](https://github.com/arjunrajlaboratory/ImageAnalysisProject/pull/162) |
+| TODO-005 | Make scoped worker builds fail when the Compose service is absent | Open | Medium | [scoped-worker-build-validation.md](scoped-worker-build-validation.md) | — |
 
 ## Completed TODOs
 

--- a/todo/scoped-worker-build-validation.md
+++ b/todo/scoped-worker-build-validation.md
@@ -1,0 +1,47 @@
+# TODO-005: Make scoped worker builds fail when the Compose service is absent
+
+**Status:** Open
+**Priority:** Medium
+**Owner:** unassigned
+**Related:** coordinate-validation hardening for the 2026-08-06 `cellposesam` crash
+
+## Problem
+
+`build_workers.sh` documents a scoped build-and-test command using a worker name:
+
+```bash
+./build_workers.sh --build-and-run-tests cellposesam
+```
+
+On 2026-08-07 that command rebuilt all three base images, then printed:
+
+```text
+no such service: cellposesam
+no such service: cellposesam_test
+no such service: cellposesam_test
+Process completed!
+```
+
+and exited with status 0. `cellposesam` is not registered in
+`docker-compose.yml`, and the script neither validates the requested service nor
+propagates the failing `docker compose` status. This makes an omitted test look
+like a successful scoped verification after an expensive base-image build.
+
+## Recommended resolution
+
+1. Validate the requested service against
+   `docker compose --profile "*" config --services` before building any base
+   images.
+2. Exit nonzero with an actionable message when the worker or its `_test`
+   service is absent.
+3. Decide whether ML workers such as `cellposesam` should be registered in
+   Compose or explicitly routed to `build_machine_learning_workers.sh` and
+   native worker tests.
+4. Add shell-level regression coverage proving a missing scoped service cannot
+   reach `Process completed!` or return status 0.
+
+## Current verification path
+
+Until this is fixed, run `workers/annotations/cellposesam/tests` natively for
+its current unit coverage. The shared `worker_client/tests` suite covers the
+coordinate preflight added for the production crash.

--- a/worker_client/tests/test_polygon_cleaning.py
+++ b/worker_client/tests/test_polygon_cleaning.py
@@ -22,6 +22,7 @@ def _load_worker_client_module(monkeypatch, annotation_client_obj=None):
     )
     tiles.UPennContrastDataset = lambda **kwargs: types.SimpleNamespace(tiles={})
     utils.sendProgress = lambda *args, **kwargs: None
+    utils.sendError = lambda *args, **kwargs: None
 
     monkeypatch.setitem(sys.modules, "annotation_client", annotation_client)
     monkeypatch.setitem(sys.modules, "annotation_client.annotations", annotations)

--- a/worker_client/tests/test_worker_client_coordinate_validation.py
+++ b/worker_client/tests/test_worker_client_coordinate_validation.py
@@ -1,0 +1,162 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _load_worker_client(monkeypatch, dataset_client, errors):
+    package_root = Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(package_root))
+
+    annotation_client = types.ModuleType("annotation_client")
+    annotations = types.ModuleType("annotation_client.annotations")
+    tiles = types.ModuleType("annotation_client.tiles")
+    utils = types.ModuleType("annotation_client.utils")
+
+    annotations.UPennContrastAnnotationClient = lambda **kwargs: types.SimpleNamespace()
+    tiles.UPennContrastDataset = lambda **kwargs: dataset_client
+    utils.sendProgress = lambda *args, **kwargs: None
+    utils.sendError = lambda message, info=None: errors.append((message, info))
+
+    monkeypatch.setitem(sys.modules, "annotation_client", annotation_client)
+    monkeypatch.setitem(sys.modules, "annotation_client.annotations", annotations)
+    monkeypatch.setitem(sys.modules, "annotation_client.tiles", tiles)
+    monkeypatch.setitem(sys.modules, "annotation_client.utils", utils)
+
+    sys.modules.pop("worker_client", None)
+    sys.modules.pop("worker_client.worker_client", None)
+    return importlib.import_module("worker_client").WorkerClient
+
+
+class DummyDatasetClient:
+    def __init__(self, index_range):
+        self.tiles = {"IndexRange": index_range}
+        self.frame_requests = []
+
+    def coordinatesToFrameIndex(self, xy, z, time, channel):
+        self.frame_requests.append((xy, z, time, channel))
+        return 0
+
+    def getRegion(self, dataset_id, frame):
+        raise AssertionError("Invalid coordinates must be rejected before image access")
+
+
+def _params(worker_interface=None):
+    return {
+        "assignment": {},
+        "channel": 0,
+        "connectTo": {"tags": []},
+        "tags": [],
+        "tile": {"XY": 0, "Z": 0, "Time": 0},
+        "workerInterface": worker_interface or {},
+    }
+
+
+def test_process_reports_zero_in_one_indexed_batch_z_before_image_access(monkeypatch):
+    errors = []
+    dataset_client = DummyDatasetClient({"IndexZ": 35})
+    WorkerClient = _load_worker_client(monkeypatch, dataset_client, errors)
+    worker = WorkerClient(
+        "dataset", "http://api", "token", _params({"Batch Z": "0-34"}))
+
+    with pytest.raises(ValueError, match="Batch Z"):
+        worker.process(lambda image: [], f_annotation="polygon")
+
+    assert dataset_client.frame_requests == []
+    assert errors == [(
+        "Batch range is out of bounds.",
+        "Batch Z contains invalid position 0. Batch positions start at 1; this "
+        "dataset has 35 Z positions, so its valid range is 1-35.",
+    )]
+
+
+def test_validate_coordinates_reports_upper_out_of_range_value(monkeypatch):
+    errors = []
+    dataset_client = DummyDatasetClient({"IndexXY": 2})
+    WorkerClient = _load_worker_client(monkeypatch, dataset_client, errors)
+    worker = WorkerClient(
+        "dataset", "http://api", "token", _params({"Batch XY": "1-3"}))
+
+    with pytest.raises(ValueError, match="Batch XY"):
+        worker.validate_coordinates()
+
+    assert errors == [(
+        "Batch range is out of bounds.",
+        "Batch XY contains invalid position 3. Batch positions start at 1; this "
+        "dataset has 2 XY positions, so its valid range is 1-2.",
+    )]
+
+
+def test_validate_coordinates_defaults_missing_dimension_size_to_one(monkeypatch):
+    errors = []
+    dataset_client = DummyDatasetClient({})
+    WorkerClient = _load_worker_client(monkeypatch, dataset_client, errors)
+    worker = WorkerClient(
+        "dataset", "http://api", "token", _params({"Batch Time": "2"}))
+
+    with pytest.raises(ValueError, match="Batch Time"):
+        worker.validate_coordinates()
+
+    assert errors[0][1] == (
+        "Batch Time contains invalid position 2. Batch positions start at 1; "
+        "this dataset has 1 Time position, so its valid range is 1-1.")
+
+
+def test_validate_coordinates_ignores_batch_for_stacked_dimension(monkeypatch):
+    errors = []
+    dataset_client = DummyDatasetClient({"IndexZ": 35})
+    WorkerClient = _load_worker_client(monkeypatch, dataset_client, errors)
+    worker = WorkerClient(
+        "dataset", "http://api", "token", _params({"Batch Z": "0"}))
+
+    worker.validate_coordinates(stack_zs="all")
+
+    assert errors == []
+
+
+def test_validate_coordinates_reports_invalid_stack_channel(monkeypatch):
+    errors = []
+    dataset_client = DummyDatasetClient({"IndexC": 1, "IndexZ": 35})
+    WorkerClient = _load_worker_client(monkeypatch, dataset_client, errors)
+    worker = WorkerClient("dataset", "http://api", "token", _params())
+
+    with pytest.raises(ValueError, match="channel index 1"):
+        worker.validate_coordinates(stack_channels=[1])
+
+    assert errors == [(
+        "Selected channels are outside this dataset.",
+        "The selected channel index 1 does not exist in this dataset, which has "
+        "1 channel (valid indices: 0-0).",
+    )]
+
+
+def test_validate_coordinates_does_not_consume_batch_ranges(monkeypatch):
+    errors = []
+    dataset_client = DummyDatasetClient({"IndexZ": 2})
+    WorkerClient = _load_worker_client(monkeypatch, dataset_client, errors)
+    worker = WorkerClient(
+        "dataset", "http://api", "token", _params({"Batch Z": "1-2"}))
+
+    worker.validate_coordinates()
+    first_read = list(worker.batch_z)
+    second_read = list(worker.batch_z)
+
+    assert first_read == [0, 1]
+    assert second_read == [0, 1]
+    assert errors == []
+
+
+def test_malformed_batch_range_reports_parse_error(monkeypatch):
+    errors = []
+    dataset_client = DummyDatasetClient({"IndexZ": 2})
+    WorkerClient = _load_worker_client(monkeypatch, dataset_client, errors)
+
+    with pytest.raises(ValueError, match="Batch Z must contain 1-based"):
+        WorkerClient(
+            "dataset", "http://api", "token",
+            _params({"Batch Z": "first-third"}))
+
+    assert errors[0][0] == "Could not read the batch range."
+    assert "for example '1-3, 5-8'" in errors[0][1]

--- a/worker_client/tests/test_worker_client_index_range.py
+++ b/worker_client/tests/test_worker_client_index_range.py
@@ -18,6 +18,7 @@ def _load_worker_client(monkeypatch, dataset_client):
     annotations.UPennContrastAnnotationClient = lambda **kwargs: types.SimpleNamespace()
     tiles.UPennContrastDataset = lambda **kwargs: dataset_client
     utils.sendProgress = lambda *args, **kwargs: None
+    utils.sendError = lambda *args, **kwargs: None
 
     monkeypatch.setitem(sys.modules, "annotation_client", annotation_client)
     monkeypatch.setitem(sys.modules, "annotation_client.annotations", annotations)

--- a/worker_client/worker_client/worker_client.py
+++ b/worker_client/worker_client/worker_client.py
@@ -9,10 +9,25 @@ from typing import Sequence
 import annotation_client.annotations as annotations
 import annotation_client.tiles as tiles
 
-from annotation_client.utils import sendProgress
+from annotation_client.utils import sendError, sendProgress
 from annotation_utilities import batch_argument_parser
 # Re-exported for workers that import it from worker_client (e.g. cellposesam).
 from annotation_utilities.annotation_tools import geometry_to_polygon_coords
+
+
+def _parse_batch_values(worker_interface, field, fallback):
+    """Parse a 1-indexed Batch field and report malformed input clearly."""
+    raw_value = worker_interface.get(field, None)
+    try:
+        values = batch_argument_parser.process_range_list(
+            raw_value, convert_one_to_zero_index=True)
+        return [fallback] if values is None else list(values)
+    except (AttributeError, TypeError, ValueError) as exc:
+        detail = (
+            f"{field} must contain 1-based positions or ranges, for example "
+            f"'1-3, 5-8'. Could not parse {raw_value!r}: {exc}")
+        sendError("Could not read the batch range.", info=detail)
+        raise ValueError(detail) from exc
 
 
 class WorkerClient:
@@ -40,27 +55,14 @@ class WorkerClient:
         self.tile = tile
         self.workerInterface = workerInterface
 
-        batch_xy = workerInterface.get('Batch XY', None)
-        batch_z = workerInterface.get('Batch Z', None)
-        batch_time = workerInterface.get('Batch Time', None)
-
-        batch_xy = batch_argument_parser.process_range_list(
-            batch_xy, convert_one_to_zero_index=True)
-        batch_z = batch_argument_parser.process_range_list(
-            batch_z, convert_one_to_zero_index=True)
-        batch_time = batch_argument_parser.process_range_list(
-            batch_time, convert_one_to_zero_index=True)
-
-        if batch_xy is None:
-            batch_xy = [tile['XY']]
-        if batch_z is None:
-            batch_z = [tile['Z']]
-        if batch_time is None:
-            batch_time = [tile['Time']]
-
-        self.batch_xy = batch_xy
-        self.batch_z = batch_z
-        self.batch_time = batch_time
+        # process_range_list returns one-shot generators. Materialize stable
+        # lists so validation and processing can inspect the same coordinates.
+        self.batch_xy = _parse_batch_values(
+            workerInterface, 'Batch XY', tile['XY'])
+        self.batch_z = _parse_batch_values(
+            workerInterface, 'Batch Z', tile['Z'])
+        self.batch_time = _parse_batch_values(
+            workerInterface, 'Batch Time', tile['Time'])
 
         annotationClient = annotations.UPennContrastAnnotationClient(
             apiUrl=apiUrl, token=token)
@@ -87,6 +89,84 @@ class WorkerClient:
             self.datasetId, frame=frame).squeeze()
 
         return image
+
+    def validate_coordinates(self, stack_xys=None, stack_zs=None,
+                             stack_times=None, stack_channels=None):
+        """Reject image coordinates that do not exist in the dataset.
+
+        Batch fields are 1-indexed in the UI but are stored on this client as
+        zero-indexed coordinates. Stack selections and channels are already
+        zero-indexed. A stacked dimension supersedes its corresponding Batch
+        field, matching :meth:`process` and :meth:`get_image_stack`.
+        """
+        index_range = self.datasetClient.tiles.get('IndexRange', {})
+
+        dimensions = (
+            ('Batch XY', 'XY', 'IndexXY', self.batch_xy,
+             stack_xys, self.tile['XY']),
+            ('Batch Z', 'Z', 'IndexZ', self.batch_z,
+             stack_zs, self.tile['Z']),
+            ('Batch Time', 'Time', 'IndexT', self.batch_time,
+             stack_times, self.tile['Time']),
+        )
+        errors = []
+
+        for field, label, index_key, batch_values, stack_values, tile_value in dimensions:
+            if stack_values == 'all':
+                continue
+            if (isinstance(stack_values, Sequence)
+                    and not isinstance(stack_values, (str, bytes))
+                    and len(stack_values)):
+                values = stack_values
+            elif stack_values is None:
+                values = batch_values
+            else:
+                # Empty stack selections fall back to the current tile in
+                # get_image_stack().
+                values = [tile_value]
+
+            size = index_range.get(index_key, 1)
+            invalid = sorted(set(value for value in values
+                                 if value < 0 or value >= size))
+            if invalid:
+                positions = [value + 1 for value in invalid]
+                position_word = 'position' if len(positions) == 1 else 'positions'
+                dataset_word = 'position' if size == 1 else 'positions'
+                errors.append(
+                    f"{field} contains invalid {position_word} "
+                    f"{', '.join(str(value) for value in positions)}. Batch "
+                    f"positions start at 1; this dataset has {size} {label} "
+                    f"{dataset_word}, so its valid range is 1-{size}.")
+
+        if errors:
+            detail = ' '.join(errors)
+            sendError("Batch range is out of bounds.", info=detail)
+            raise ValueError(detail)
+
+        if stack_channels == 'all':
+            return
+        if (isinstance(stack_channels, Sequence)
+                and not isinstance(stack_channels, (str, bytes))
+                and len(stack_channels)):
+            channels = stack_channels
+        else:
+            channels = [self.channel]
+
+        num_channels = index_range.get('IndexC', 1)
+        invalid_channels = sorted(set(
+            channel for channel in channels
+            if channel < 0 or channel >= num_channels))
+        if invalid_channels:
+            index_word = 'index' if len(invalid_channels) == 1 else 'indices'
+            channel_word = 'channel' if num_channels == 1 else 'channels'
+            detail = (
+                f"The selected channel {index_word} "
+                f"{', '.join(str(channel) for channel in invalid_channels)} "
+                f"{'does' if len(invalid_channels) == 1 else 'do'} not exist in "
+                f"this dataset, which has {num_channels} {channel_word} "
+                f"(valid indices: 0-{num_channels - 1}).")
+            sendError("Selected channels are outside this dataset.", info=detail)
+            raise ValueError(detail)
 
     def get_image_stack(self, location, stack_xys=None, stack_zs=None, stack_times=None, stack_channels=None):
 
@@ -252,6 +332,9 @@ class WorkerClient:
 
     def process(self, f_process, f_annotation, stack_xys=None, stack_zs=None, stack_times=None, stack_channels=None,
                 progress_text='Running Worker'):
+
+        self.validate_coordinates(stack_xys, stack_zs,
+                                  stack_times, stack_channels)
 
         if f_annotation == 'point':
             f_annotation = self.create_point_annotations

--- a/workers/annotations/cellposesam/CELLPOSESAM.md
+++ b/workers/annotations/cellposesam/CELLPOSESAM.md
@@ -16,9 +16,9 @@ This worker runs Cellpose-SAM, a variant of Cellpose that combines Cellpose with
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | **Cellpose-SAM** | notes | -- | Informational text with documentation link |
-| **Batch XY** | text | -- | XY positions to iterate over (e.g., "1-3, 5-8") |
-| **Batch Z** | text | -- | Z slices to iterate over |
-| **Batch Time** | text | -- | Time points to iterate over |
+| **Batch XY** | text | -- | 1-indexed XY positions to iterate over (e.g., "1-3, 5-8") |
+| **Batch Z** | text | -- | 1-indexed Z slices to iterate over |
+| **Batch Time** | text | -- | 1-indexed Time points to iterate over |
 | **Model** | select | cellpose-sam | Model to use. `cellpose-sam` runs the `cpsam_v2` checkpoint (current default); `cellpose-sam (legacy cpsam)` runs the original April 2025 `cpsam` checkpoint. User-trained models from Girder are also listed |
 | **Channel for Slot 1** | channelCheckboxes | -- | **Required.** Source channel(s) for the model's first input slot. If multiple selected, only the first is used |
 | **Channel for Slot 2** | channelCheckboxes | -- | Optional second input slot channel |
@@ -44,6 +44,13 @@ Unlike the standard Cellpose worker which uses Primary/Secondary channel selecto
 
 - **Base models**: The dropdown labels map to cellpose built-in checkpoints in `models_config.py` — `cellpose-sam` → `cpsam_v2`, `cellpose-sam (legacy cpsam)` → `cpsam`. The selected checkpoint name is passed explicitly as `pretrained_model` rather than relying on Cellpose's internal default, which can shift between versions.
 - **Custom models**: Loaded from Girder by path. Like built-in Cellpose-SAM checkpoints, they run at native resolution with no diameter rescaling.
+
+### Batch Validation
+
+Batch XY/Z/Time values are validated against the dataset before the GPU model
+is loaded. The fields use 1-based positions, so `0` is invalid; out-of-range
+values produce a user-facing error that includes the dataset's valid range.
+Selected input channels are range-checked at the same preflight stage.
 
 ### Built-in Checkpoints
 

--- a/workers/annotations/cellposesam/entrypoint.py
+++ b/workers/annotations/cellposesam/entrypoint.py
@@ -234,6 +234,10 @@ def compute(datasetId, apiUrl, token, params):
     smoothing = float(worker.workerInterface['Smoothing'])
 
     stack_channels = get_slot_channels(worker.workerInterface)
+    # Validate the 1-indexed Batch fields and selected input channels before
+    # loading the large GPU model. WorkerClient.process() repeats this check as
+    # a defense-in-depth measure shared by all workers that use it.
+    worker.validate_coordinates(stack_channels=stack_channels)
 
     print(f"Using channels for Cellpose-SAM input (slots 1, 2, 3): {stack_channels}")
 


### PR DESCRIPTION
## Summary

- validate Batch XY/Z/Time coordinates against dataset `IndexRange` before image access
- report that batch positions start at 1 and include the dataset's valid range
- report malformed batch syntax through `sendError` instead of leaking parser exceptions
- validate stacked channel selections and preserve parsed batch ranges across repeated preflight checks
- run the Cellpose-SAM preflight before loading the GPU model
- document Cellpose-SAM's 1-indexed batch contract and record the scoped Compose test-runner gap discovered during verification

## Root cause

Batch fields are entered as 1-indexed positions and converted to zero-based coordinates. The production value `Batch Z: "0-34"` therefore became `[-1, ..., 33]`. `WorkerClient` passed `-1` directly to `coordinatesToFrameIndex`, where the dataset map raised `KeyError: -1` without first sending a useful worker error.

The earlier `Failed to get docker network` hostname-resolution message was non-fatal: the container started, detected CUDA, and reached image loading before the coordinate failure.

## Impact

Invalid batch coordinates now fail before frame lookup, with a message such as: `Batch Z contains invalid position 0. Batch positions start at 1; ... valid range is 1-35.` Cellpose-SAM performs this validation before constructing the large model, and all workers using `WorkerClient.process()` inherit the shared guard.

## Validation

- `pytest -q worker_client/tests` — 19 passed
- `pytest -q annotation_utilities/tests` — 61 passed
- `pytest -q workers/annotations/cellposesam/tests` — 13 passed
- `python -m py_compile` for the changed Python modules
- `git diff --check`

`./build_workers.sh --build-and-run-tests cellposesam` successfully rebuilt the shared base images but did not run a worker test because `cellposesam`/`cellposesam_test` are absent from Compose; the script nevertheless returned zero. That pre-existing build-runner issue is documented as TODO-005 in this PR.