### PR TITLE
Fix children_count_worker crash on empty DataFrame groupby

### DIFF
--- a/.agents/skills/nimbus-worker-hardening/SKILL.md
+++ b/.agents/skills/nimbus-worker-hardening/SKILL.md
@@ -263,6 +263,47 @@ Don't confuse this with `params['tags']` used for **property filtering**, which
 `nimbus-interface` skill and `AGENTS.md` for the full interface type→return
 table.
 
+### 7. `groupby` on a DataFrame built from an empty list
+
+**Symptom:** `KeyError: '<column>'` from `pandas` deep inside `groupby`/column
+access, on a dataset where a filter step matched nothing. `pd.DataFrame([])`
+has **no columns at all**, so `df.groupby('parentId')` raises `KeyError:
+'parentId'` instead of returning an empty result. The June 2026 production case
+was children_count_worker run with `'Child Tags': []` — an empty tag set
+intersects with nothing, so `filtered_connections` was `[]`.
+
+**Two fixes, both needed:**
+1. Validate the required selection early and `sendError` (an empty required
+   `tags` field is a misconfiguration — same validation pattern as catalog #6):
+   ```python
+   if not child_tags:
+       sendError("No child tag selected", info="Select at least one tag ...")
+       return
+   ```
+2. Guard the groupby — an empty *result* (valid tags, zero matches) is
+   legitimate data, so skip pandas and report counts of 0 with a `sendWarning`:
+   ```python
+   if filtered_connections:
+       df = pd.DataFrame(filtered_connections)
+       counts = df.groupby('parentId').size().reset_index(name='count')
+   else:
+       counts_dict = {}   # every parent gets 0; sendWarning explains why
+   ```
+Pre-declaring columns also works when a DataFrame must exist either way:
+`pd.DataFrame(connections, columns=['parentId', 'childId'])` — this is why
+connect_to_nearest/connect_sequential (which initialize
+`pd.DataFrame(columns=[...])`) never crashed.
+
+**Sweep:**
+```bash
+grep -rn "pd\.DataFrame(" workers/ | grep -v "columns="   # then check each for a possibly-empty list feeding a groupby/column access
+```
+Swept 2026-08: children_count_worker was the only worker with the pattern
+(fixed; regression tests in its `tests/test_children_count.py`). Note its old
+tests mocked `pandas.DataFrame` entirely, which is how the crash survived —
+when adding tests for a pandas path, use real pandas with an **empty** input
+list; a mocked groupby chain can't catch this class of bug.
+
 ## After fixing
 
 - Run the relevant package tests (`annotation_utilities`, `worker_client`) and

--- a/.claude/skills/nimbus-worker-hardening/SKILL.md
+++ b/.claude/skills/nimbus-worker-hardening/SKILL.md
@@ -263,6 +263,47 @@ Don't confuse this with `params['tags']` used for **property filtering**, which
 `nimbus-interface` skill and `CLAUDE.md` for the full interface type→return
 table.
 
+### 7. `groupby` on a DataFrame built from an empty list
+
+**Symptom:** `KeyError: '<column>'` from `pandas` deep inside `groupby`/column
+access, on a dataset where a filter step matched nothing. `pd.DataFrame([])`
+has **no columns at all**, so `df.groupby('parentId')` raises `KeyError:
+'parentId'` instead of returning an empty result. The June 2026 production case
+was children_count_worker run with `'Child Tags': []` — an empty tag set
+intersects with nothing, so `filtered_connections` was `[]`.
+
+**Two fixes, both needed:**
+1. Validate the required selection early and `sendError` (an empty required
+   `tags` field is a misconfiguration — same validation pattern as catalog #6):
+   ```python
+   if not child_tags:
+       sendError("No child tag selected", info="Select at least one tag ...")
+       return
+   ```
+2. Guard the groupby — an empty *result* (valid tags, zero matches) is
+   legitimate data, so skip pandas and report counts of 0 with a `sendWarning`:
+   ```python
+   if filtered_connections:
+       df = pd.DataFrame(filtered_connections)
+       counts = df.groupby('parentId').size().reset_index(name='count')
+   else:
+       counts_dict = {}   # every parent gets 0; sendWarning explains why
+   ```
+Pre-declaring columns also works when a DataFrame must exist either way:
+`pd.DataFrame(connections, columns=['parentId', 'childId'])` — this is why
+connect_to_nearest/connect_sequential (which initialize
+`pd.DataFrame(columns=[...])`) never crashed.
+
+**Sweep:**
+```bash
+grep -rn "pd\.DataFrame(" workers/ | grep -v "columns="   # then check each for a possibly-empty list feeding a groupby/column access
+```
+Swept 2026-08: children_count_worker was the only worker with the pattern
+(fixed; regression tests in its `tests/test_children_count.py`). Note its old
+tests mocked `pandas.DataFrame` entirely, which is how the crash survived —
+when adding tests for a pandas path, use real pandas with an **empty** input
+list; a mocked groupby chain can't catch this class of bug.
+
 ## After fixing
 
 - Run the relevant package tests (`annotation_utilities`, `worker_client`) and

--- a/workers/properties/connections/children_count_worker/CHILDREN_COUNT.md
+++ b/workers/properties/connections/children_count_worker/CHILDREN_COUNT.md
@@ -29,6 +29,12 @@ Parent annotations are filtered using the standard tag selector in the property 
 5. Assigns a count of 0 to any parent annotation that has no matching children.
 6. Uploads all property values in a single batch.
 
+## Error Handling
+
+- **Empty "Child Tags"** (nothing selected): the worker stops with an error asking the user to select at least one child tag. An empty tag set matches no annotations, so running would silently produce all-zero counts (and previously crashed with `KeyError: 'parentId'` on the empty-DataFrame groupby).
+- **No annotations match the parent or child tags**: the worker sends a warning naming the unmatched tags and continues; every parent gets a count of 0.
+- **No connections between matching parents and children**: the worker sends a warning suggesting a connection tool (e.g. "Connect to nearest") be run first, and uploads counts of 0 — a parent with no children is valid data.
+
 ## Notes
 
 - Tag filtering supports both exclusive mode (annotations must have exactly the specified tags) and inclusive mode (annotations must have at least one matching tag).

--- a/workers/properties/connections/children_count_worker/entrypoint.py
+++ b/workers/properties/connections/children_count_worker/entrypoint.py
@@ -4,7 +4,7 @@ import sys
 
 import annotation_client.annotations as annotations
 import annotation_client.workers as workers
-from annotation_client.utils import sendProgress
+from annotation_client.utils import sendProgress, sendWarning, sendError
 
 
 
@@ -42,9 +42,19 @@ def compute(datasetId, apiUrl, token, params):
     parent_tags = set(params.get('tags', {}).get('tags', []))
     parent_exclusive = params.get('tags', {}).get('exclusive', False)
 
-    child_tags = set(workerInterface.get('Child Tags', []))
+    child_tags = set(workerInterface.get('Child Tags', []) or [])
     print(workerInterface)
-    child_exclusive = workerInterface['Child Tags Exclusive'] == 'Yes'
+    child_exclusive = workerInterface.get('Child Tags Exclusive', 'No') == 'Yes'
+
+    # An empty tag set matches no annotations (set intersection with an empty
+    # set is always empty), so without this check the worker computes nothing
+    # and crashes on the empty-DataFrame groupby below.
+    if not child_tags:
+        sendError(
+            "No child tag selected",
+            info="Select at least one tag in 'Child Tags' so the worker knows "
+                 "which annotations to count as children of each parent.")
+        return
 
     workerClient = workers.UPennContrastWorkerClient(datasetId, apiUrl, token, params)
     annotationClient = annotations.UPennContrastAnnotationClient(apiUrl=apiUrl, token=token)
@@ -66,6 +76,17 @@ def compute(datasetId, apiUrl, token, params):
     parent_annotations = filter_annotations(all_annotations, parent_tags, parent_exclusive)
     child_annotations = filter_annotations(all_annotations, child_tags, child_exclusive)
 
+    if not parent_annotations:
+        sendWarning(
+            "No parent annotations found",
+            info=f"No annotations match the parent tag(s) {sorted(parent_tags)}, "
+                 "so there is nothing to count children for.")
+    if not child_annotations:
+        sendWarning(
+            "No child annotations found",
+            info=f"No annotations have the selected child tag(s) {sorted(child_tags)}. "
+                 "Every parent will get a count of 0.")
+
     parent_ids = set(ann['_id'] for ann in parent_annotations)
     child_ids = set(ann['_id'] for ann in child_annotations)
 
@@ -76,9 +97,22 @@ def compute(datasetId, apiUrl, token, params):
 
     sendProgress(0.7, 'Computing', 'Counting children')
 
-    df = pd.DataFrame(filtered_connections)
-    children_count = df.groupby('parentId').size().reset_index(name='count')
-    children_count_dict = dict(zip(children_count['parentId'], children_count['count']))
+    # A DataFrame built from an empty list has no columns at all, so
+    # groupby('parentId') on it raises KeyError rather than returning an
+    # empty result. Zero matching connections is a legitimate outcome
+    # (every parent simply has 0 children), so skip pandas entirely.
+    if filtered_connections:
+        df = pd.DataFrame(filtered_connections)
+        children_count = df.groupby('parentId').size().reset_index(name='count')
+        children_count_dict = dict(zip(children_count['parentId'], children_count['count']))
+    else:
+        children_count_dict = {}
+        if parent_annotations and child_annotations:
+            sendWarning(
+                "No connections found",
+                info="No connections exist between the parent and child annotations. "
+                     "Every parent will get a count of 0. If you expected non-zero "
+                     "counts, run a connection tool (e.g. 'Connect to nearest') first.")
 
     property_value_dict = {
         parent_id: children_count_dict.get(parent_id, 0)

--- a/workers/properties/connections/children_count_worker/tests/test_children_count.py
+++ b/workers/properties/connections/children_count_worker/tests/test_children_count.py
@@ -435,79 +435,125 @@ def test_parent_with_no_children(mock_worker_client, mock_annotation_client, sam
                     pass
 
 
-def test_empty_tag_filters(mock_worker_client, mock_annotation_client):
-    """Test behavior when no child tags are specified"""
-    # Create parameters with empty child tags
+def test_empty_child_tags_sends_error(mock_worker_client, mock_annotation_client):
+    """Regression test: empty 'Child Tags' must sendError, not crash.
+
+    A production job ran with 'Child Tags': []. An empty tag set matches no
+    annotations, so filtered_connections was empty and
+    pd.DataFrame([]).groupby('parentId') raised KeyError: 'parentId'. The
+    worker must now report a clear error instead.
+    """
+    # The exact workerInterface from the failed production job
     empty_tag_params = {
         'id': 'test_property_id',
-        'name': 'Children Count',
+        'name': 'DAPI blob Count connected objects',
         'image': 'properties/children_count:latest',
         'tags': {'exclusive': False, 'tags': ['nucleus']},
         'shape': 'polygon',
         'workerInterface': {
-            'Child Tags': [],  # Empty tag list
-            'Child Tags Exclusive': 'No'
+            'Child Tags': [],
+            'Child Tags Exclusive': 'No',
+            'Count connected objects': ''
         }
     }
 
-    # Create parent and child annotations
     parent = {
         '_id': 'parent_1',
         'coordinates': [{'x': 0, 'y': 0}, {'x': 0, 'y': 10}, {'x': 10, 'y': 10},
                         {'x': 10, 'y': 0}, {'x': 0, 'y': 0}],
         'tags': ['nucleus']
     }
-
     child1 = {'_id': 'child_1', 'coordinates': [{'x': 5, 'y': 5}], 'tags': ['spot']}
-    child2 = {'_id': 'child_2', 'coordinates': [{'x': 8, 'y': 8}], 'tags': ['other']}
 
-    # Set up mock to return our annotations
-    mock_worker_client.get_annotation_list_by_shape.return_value = [parent, child1, child2]
-
-    # Create connections
-    connections = [
-        {'parentId': 'parent_1', 'childId': 'child_1', 'dataset': 'test_dataset'},
-        {'parentId': 'parent_1', 'childId': 'child_2', 'dataset': 'test_dataset'}
+    mock_worker_client.get_annotation_list_by_shape.return_value = [parent, child1]
+    mock_annotation_client.getAnnotationConnections.return_value = [
+        {'parentId': 'parent_1', 'childId': 'child_1', 'dataset': 'test_dataset'}
     ]
 
-    # Set up mock to return our connections
-    mock_annotation_client.getAnnotationConnections.return_value = connections
+    with patch('entrypoint.sendError') as mock_send_error:
+        compute('test_dataset', 'http://test-api', 'test-token', empty_tag_params)
 
-    # Mock sendProgress to avoid errors
-    with patch('annotation_client.utils.sendProgress'):
-        # Mock pandas to avoid recursion issues
-        with patch('pandas.DataFrame') as mock_df:
-            # Create a mock DataFrame that will be returned by the DataFrame constructor
-            mock_df_instance = MagicMock()
-            mock_df.return_value = mock_df_instance
+        # The worker must report the misconfiguration to the user...
+        mock_send_error.assert_called_once()
+        assert 'No child tag selected' in mock_send_error.call_args[0][0]
 
-            # Mock the groupby chain to return a DataFrame with our expected count
-            # With empty tag filter, all children should be counted
-            mock_count_df = MagicMock()
-            mock_df_instance.groupby.return_value.size.return_value.reset_index.return_value = mock_count_df
+        # ...and must not upload any property values
+        mock_worker_client.add_multiple_annotation_property_values.assert_not_called()
 
-            # Set up the mock DataFrame to behave like a dictionary when accessed with __getitem__
-            mock_count_df.__getitem__.side_effect = lambda key: [
-                'parent_1'] if key == 'parentId' else [2]
 
-            # Set up the mock DataFrame to behave like a list when iterated
-            mock_count_df.__iter__.return_value = [{'parentId': 'parent_1', 'count': 2}]
+def test_missing_child_tags_field_sends_error(mock_worker_client, mock_annotation_client):
+    """An interface missing the 'Child Tags' key entirely must also sendError."""
+    params = {
+        'id': 'test_property_id',
+        'name': 'Children Count',
+        'image': 'properties/children_count:latest',
+        'tags': {'exclusive': False, 'tags': ['nucleus']},
+        'shape': 'polygon',
+        'workerInterface': {}  # no 'Child Tags', no 'Child Tags Exclusive'
+    }
 
-            # Set up the zip function to return a list of tuples
-            with patch('builtins.zip') as mock_zip:
-                mock_zip.return_value = [('parent_1', 2)]
+    with patch('entrypoint.sendError') as mock_send_error:
+        compute('test_dataset', 'http://test-api', 'test-token', params)
 
-                # Run computation with empty tag filter
-                compute('test_dataset', 'http://test-api', 'test-token', empty_tag_params)
+        mock_send_error.assert_called_once()
+        mock_worker_client.add_multiple_annotation_property_values.assert_not_called()
 
-                # Verify that add_multiple_annotation_property_values was called
-                mock_worker_client.add_multiple_annotation_property_values.assert_called_once()
 
-                # Get the property values that were sent to the server
-                property_values = mock_worker_client.add_multiple_annotation_property_values.call_args[
-                    0][0]
-                assert 'test_dataset' in property_values
+def test_no_connections_uploads_zero_counts(mock_worker_client, mock_annotation_client,
+                                            sample_params):
+    """Valid tags but zero matching connections: every parent gets 0, no crash.
 
-                # Check that the parent annotation has a count of 2 (all children should be counted)
-                assert 'parent_1' in property_values['test_dataset']
-                assert property_values['test_dataset']['parent_1'] == 2
+    Uses the real (unmocked) code path: with no connections the worker must
+    skip the pandas groupby (an empty DataFrame has no 'parentId' column) and
+    warn the user that all counts are 0.
+    """
+    parent = {
+        '_id': 'parent_1',
+        'coordinates': [{'x': 0, 'y': 0}, {'x': 0, 'y': 10}, {'x': 10, 'y': 10},
+                        {'x': 10, 'y': 0}, {'x': 0, 'y': 0}],
+        'tags': ['nucleus']
+    }
+    child1 = {'_id': 'child_1', 'coordinates': [{'x': 5, 'y': 5}], 'tags': ['spot']}
+
+    mock_worker_client.get_annotation_list_by_shape.return_value = [parent, child1]
+    mock_annotation_client.getAnnotationConnections.return_value = []
+
+    with patch('entrypoint.sendWarning') as mock_send_warning:
+        compute('test_dataset', 'http://test-api', 'test-token', sample_params)
+
+        # The user is told why every count is 0
+        warning_titles = [call.args[0] for call in mock_send_warning.call_args_list]
+        assert 'No connections found' in warning_titles
+
+        # Zero counts are still uploaded — a parent with no children is valid data
+        mock_worker_client.add_multiple_annotation_property_values.assert_called_once()
+        property_values = mock_worker_client.add_multiple_annotation_property_values.call_args[0][0]
+        assert property_values['test_dataset']['parent_1'] == 0
+
+
+def test_no_matching_child_annotations_warns_and_uploads_zeros(
+        mock_worker_client, mock_annotation_client, sample_params):
+    """Child tags that match no annotations: warn and upload zeros, no crash."""
+    parent = {
+        '_id': 'parent_1',
+        'coordinates': [{'x': 0, 'y': 0}, {'x': 0, 'y': 10}, {'x': 10, 'y': 10},
+                        {'x': 10, 'y': 0}, {'x': 0, 'y': 0}],
+        'tags': ['nucleus']
+    }
+    # The only other annotation does NOT carry the 'spot' child tag
+    other = {'_id': 'other_1', 'coordinates': [{'x': 5, 'y': 5}], 'tags': ['other']}
+
+    mock_worker_client.get_annotation_list_by_shape.return_value = [parent, other]
+    mock_annotation_client.getAnnotationConnections.return_value = [
+        {'parentId': 'parent_1', 'childId': 'other_1', 'dataset': 'test_dataset'}
+    ]
+
+    with patch('entrypoint.sendWarning') as mock_send_warning:
+        compute('test_dataset', 'http://test-api', 'test-token', sample_params)
+
+        warning_titles = [call.args[0] for call in mock_send_warning.call_args_list]
+        assert 'No child annotations found' in warning_titles
+
+        mock_worker_client.add_multiple_annotation_property_values.assert_called_once()
+        property_values = mock_worker_client.add_multiple_annotation_property_values.call_args[0][0]
+        assert property_values['test_dataset']['parent_1'] == 0


### PR DESCRIPTION
## Summary

Fixes a production crash in `children_count_worker` where an empty `'Child Tags'` selection caused `pd.DataFrame([]).groupby('parentId')` to raise `KeyError: 'parentId'`. The worker now validates required inputs early and handles zero-match scenarios gracefully with appropriate error/warning messages.

## Changes

**entrypoint.py:**
- Added validation to reject empty `child_tags` with a clear `sendError` message asking the user to select at least one child tag
- Fixed unsafe dictionary access: `workerInterface['Child Tags Exclusive']` → `.get('Child Tags Exclusive', 'No')`
- Added guards before pandas operations to handle empty result sets:
  - Skip `groupby` entirely when `filtered_connections` is empty (legitimate outcome: no connections exist)
  - Return empty dict and send `sendWarning` instead of crashing
- Added warnings for other zero-match scenarios:
  - No parent annotations found (parent tags don't match anything)
  - No child annotations found (child tags don't match anything)
  - No connections between matching parents and children (suggests running a connection tool first)

**test_children_count.py:**
- Replaced the old `test_empty_tag_filters` test (which mocked pandas and missed the crash) with three focused regression tests:
  - `test_empty_child_tags_sends_error`: Verifies empty tag list triggers `sendError` and prevents upload
  - `test_missing_child_tags_field_sends_error`: Verifies missing `'Child Tags'` key also triggers error
  - `test_no_connections_uploads_zero_counts`: Real pandas path with zero connections → warns and uploads zeros
  - `test_no_matching_child_annotations_warns_and_uploads_zeros`: Valid tags but zero matches → warns and uploads zeros
- All new tests use real (unmocked) pandas to catch DataFrame edge cases

**CHILDREN_COUNT.md:**
- Added "Error Handling" section documenting the three error/warning scenarios and their user-facing messages

## Implementation Details

The fix follows the pattern from the nimbus-worker-hardening skill (catalog #6 and #7):
1. **Validate required selections early** — empty tag sets are misconfiguration, not valid data
2. **Guard pandas operations** — `pd.DataFrame([])` has no columns, so `groupby` fails; check for empty input before calling it
3. **Distinguish misconfiguration from valid zero-match** — `sendError` for missing required input, `sendWarning` for legitimate zero results

The old tests mocked `pandas.DataFrame` entirely, which is why the crash survived code review. New tests use real pandas with empty inputs to catch this class of bug.

https://claude.ai/code/session_01Mbm8CVwCNx2kdcPLadmsLA